### PR TITLE
Config Option to Disable Setting Up Admin Routes

### DIFF
--- a/src/PermissionManagerServiceProvider.php
+++ b/src/PermissionManagerServiceProvider.php
@@ -68,7 +68,9 @@ class PermissionManagerServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->setupRoutes($this->app->router);
+        if (config('backpack.permissionmanager.setup_role_routes', true)) {
+            $this->setupRoutes($this->app->router);
+        }
 
         $this->app->register(PermissionServiceProvider::class);
     }

--- a/src/config/backpack/permissionmanager.php
+++ b/src/config/backpack/permissionmanager.php
@@ -16,9 +16,13 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Set this to false if you would like to use your own AuthController and PasswordController
-    | (you then need to setup your auth routes manually in your routes.php file)
-     */
+    | Set this to false if you would like to stop the permission manager from
+    | registering any default routes such as 'admin/role', 'admin/permission',
+    | and 'admin/user'.
+    |
+    | You will have to setup your own if you wish to expose the CRUD
+    | functionality in your web app.
+    */
     'setup_role_routes' => false,
 
     /*

--- a/src/config/backpack/permissionmanager.php
+++ b/src/config/backpack/permissionmanager.php
@@ -16,6 +16,13 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Set this to false if you would like to use your own AuthController and PasswordController
+    | (you then need to setup your auth routes manually in your routes.php file)
+     */
+    'setup_role_routes' => false,
+
+    /*
+    |--------------------------------------------------------------------------
     | Disallow the user interface for creating/updating permissions or roles.
     |--------------------------------------------------------------------------
     | Roles and permissions are used in code by their name


### PR DESCRIPTION
https://github.com/Laravel-Backpack/PermissionManager/issues/78

This change:

1. Preserves current behaviour
2. However if the config `backpack.permissionmanager.setup_role_routes` is setup as below the setting up of routes is not performed

```
    'setup_role_routes' => false,
````

It is possible each route should be split into a separate configuration (which would be easy enough to do) but this is somewhat based on the similar functionality in Laravel-Backpack/base.

Tested on a test rig with:

1. No config present (roles setup);
2. Config set to `true` (roles setup);
3. Config set to `false` (404 thrown where the usual controller/crud panels are found)