### PR TITLE
Fixed artisan migrate error "1071 Specified key was too long"

### DIFF
--- a/src/database/migrations/2016_05_10_130540_create_permission_tables.php
+++ b/src/database/migrations/2016_05_10_130540_create_permission_tables.php
@@ -16,13 +16,13 @@ class CreatePermissionTables extends Migration
 
         Schema::create($config['roles'], function (Blueprint $table) {
             $table->increments('id');
-            $table->string('name')->unique();
+            $table->string('name', 127)->unique();
             $table->timestamps();
         });
 
         Schema::create($config['permissions'], function (Blueprint $table) {
             $table->increments('id');
-            $table->string('name')->unique();
+            $table->string('name', 127)->unique();
             $table->timestamps();
         });
 


### PR DESCRIPTION
Error:
`[Illuminate\Database\QueryException] SQLSTATE[42000]: Syntax error or access violation: 1071 Specified key was too long; max key length is 767 bytes (SQL: alter table roles add unique roles_name_unique(name))`

By adjust the size of the name to 127 (instead of the default 255) the error is solved, also 127 is enough for a user role name.
I'm using xampp v3.2.2 with MariaDB v10.1.21, very common setup.