### PR TITLE
Use tables_names.users config for User validation

### DIFF
--- a/src/app/Http/Requests/UserStoreCrudRequest.php
+++ b/src/app/Http/Requests/UserStoreCrudRequest.php
@@ -25,7 +25,7 @@ class UserStoreCrudRequest extends FormRequest
     public function rules()
     {
         $rules = [
-            'email'    => 'required|unique:users,email',
+            'email'    => 'required|unique:'.config('laravel-permission.table_names.users', 'users').',email',
             'name'     => 'required',
             'password' => 'required|confirmed',
             ];


### PR DESCRIPTION
If our user table isn't named "users", we have a SQL error. We have to use user tablename defined by spatie/laravel-permission configuration.