### PR TITLE
Clear cache key spatie.permission.cache

### DIFF
--- a/src/app/Http/Controllers/PermissionCrudController.php
+++ b/src/app/Http/Controllers/PermissionCrudController.php
@@ -58,11 +58,15 @@ class PermissionCrudController extends CrudController
 
     public function store(StoreRequest $request)
     {
+        //otherwise, changes won't have effect
+        \Cache::forget('spatie.permission.cache');
         return parent::storeCrud();
     }
 
     public function update(UpdateRequest $request)
     {
+        //otherwise, changes won't have effect
+        \Cache::forget('spatie.permission.cache');
         return parent::updateCrud();
     }
 }


### PR DESCRIPTION
Changes in permissions/roles don't have effect unless we clear its cache key

\Cache::forget('spatie.permission.cache');