### PR TITLE
Preparing laravel-permission v2 upgrade

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     "require": {
         "illuminate/support": "~5.1",
         "php" : ">=5.3.0",
-        "spatie/laravel-permission": "^1.4",
+        "spatie/laravel-permission": "2.*",
         "backpack/crud": "^3.2.0"
     },
     "require-dev": {

--- a/src/config/laravel-permission.php
+++ b/src/config/laravel-permission.php
@@ -54,17 +54,6 @@ return [
 
         /*
         |--------------------------------------------------------------------------
-        | Users Table
-        |--------------------------------------------------------------------------
-        |
-        | The table that your application uses for users. This table's model will
-        | be using the "HasRoles" and "HasPermissions" traits.
-        |
-        */
-        'users' => 'users',
-
-        /*
-        |--------------------------------------------------------------------------
         | Roles Table
         |--------------------------------------------------------------------------
         |
@@ -90,43 +79,28 @@ return [
         'permissions' => 'permissions',
 
         /*
-        |--------------------------------------------------------------------------
-        | User Permissions Table
-        |--------------------------------------------------------------------------
-        |
-        | When using the "HasRoles" trait from this package, we need to know which
-        | table should be used to retrieve your users permissions. We have chosen a
-        | basic default value but you may easily change it to any table you like.
-        |
-        */
+         * When using the "HasRoles" trait from this package, we need to know which
+         * table should be used to retrieve your models permissions. We have chosen a
+         * basic default value but you may easily change it to any table you like.
+         */
 
-        'user_has_permissions' => 'permission_users',
+        'model_has_permissions' => 'model_has_permissions',
 
         /*
-        |--------------------------------------------------------------------------
-        | User Roles Table
-        |--------------------------------------------------------------------------
-        |
-        | When using the "HasRoles" trait from this package, we need to know which
-        | table should be used to retrieve your users roles. We have chosen a
-        | basic default value but you may easily change it to any table you like.
-        |
-        */
+         * When using the "HasRoles" trait from this package, we need to know which
+         * table should be used to retrieve your models roles. We have chosen a
+         * basic default value but you may easily change it to any table you like.
+         */
 
-        'user_has_roles' => 'role_users',
+        'model_has_roles' => 'model_has_roles',
 
         /*
-        |--------------------------------------------------------------------------
-        | Role Permissions Table
-        |--------------------------------------------------------------------------
-        |
-        | When using the "HasRoles" trait from this package, we need to know which
-        | table should be used to retrieve your roles permissions. We have chosen a
-        | basic default value but you may easily change it to any table you like.
-        |
-        */
+         * When using the "HasRoles" trait from this package, we need to know which
+         * table should be used to retrieve your roles permissions. We have chosen a
+         * basic default value but you may easily change it to any table you like.
+         */
 
-        'role_has_permissions' => 'permission_roles',
+        'role_has_permissions' => 'role_has_permissions',
 
     ],
 

--- a/src/database/migrations/2016_05_10_130540_create_permission_tables.php
+++ b/src/database/migrations/2016_05_10_130540_create_permission_tables.php
@@ -12,69 +12,62 @@ class CreatePermissionTables extends Migration
      */
     public function up()
     {
-        $config = config('laravel-permission.table_names');
+        $tableNames = config('permission.table_names');
+        $foreignKeys = config('permission.foreign_keys');
 
-        Schema::create($config['roles'], function (Blueprint $table) {
+        Schema::create($tableNames['permissions'], function (Blueprint $table) {
             $table->increments('id');
-            $table->string('name')->unique();
+            $table->string('name');
+            $table->string('guard_name');
             $table->timestamps();
         });
 
-        Schema::create($config['permissions'], function (Blueprint $table) {
+        Schema::create($tableNames['roles'], function (Blueprint $table) {
             $table->increments('id');
-            $table->string('name')->unique();
+            $table->string('name');
+            $table->string('guard_name');
             $table->timestamps();
         });
 
-        Schema::create($config['user_has_permissions'], function (Blueprint $table) use ($config) {
-            $table->integer('user_id')->unsigned();
+        Schema::create($tableNames['model_has_permissions'], function (Blueprint $table) use ($tableNames, $foreignKeys) {
             $table->integer('permission_id')->unsigned();
-
-            $table->foreign('user_id')
-                ->references('id')
-                ->on($config['users'])
-                ->onDelete('cascade');
+            $table->morphs('model');
 
             $table->foreign('permission_id')
                 ->references('id')
-                ->on($config['permissions'])
+                ->on($tableNames['permissions'])
                 ->onDelete('cascade');
 
-            $table->primary(['user_id', 'permission_id']);
+            $table->primary(['permission_id', 'model_id', 'model_type']);
         });
 
-        Schema::create($config['user_has_roles'], function (Blueprint $table) use ($config) {
+        Schema::create($tableNames['model_has_roles'], function (Blueprint $table) use ($tableNames, $foreignKeys) {
             $table->integer('role_id')->unsigned();
-            $table->integer('user_id')->unsigned();
+            $table->morphs('model');
 
             $table->foreign('role_id')
                 ->references('id')
-                ->on($config['roles'])
+                ->on($tableNames['roles'])
                 ->onDelete('cascade');
 
-            $table->foreign('user_id')
+            $table->primary(['role_id', 'model_id', 'model_type']);
+        });
+
+        Schema::create($tableNames['role_has_permissions'], function (Blueprint $table) use ($tableNames) {
+            $table->integer('permission_id')->unsigned();
+            $table->integer('role_id')->unsigned();
+
+            $table->foreign('permission_id')
                 ->references('id')
-                ->on($config['users'])
+                ->on($tableNames['permissions'])
                 ->onDelete('cascade');
 
-            $table->primary(['role_id', 'user_id']);
+            $table->foreign('role_id')
+                ->references('id')
+                ->on($tableNames['roles'])
+                ->onDelete('cascade');
 
-            Schema::create($config['role_has_permissions'], function (Blueprint $table) use ($config) {
-                $table->integer('permission_id')->unsigned();
-                $table->integer('role_id')->unsigned();
-
-                $table->foreign('permission_id')
-                    ->references('id')
-                    ->on($config['permissions'])
-                    ->onDelete('cascade');
-
-                $table->foreign('role_id')
-                    ->references('id')
-                    ->on($config['roles'])
-                    ->onDelete('cascade');
-
-                $table->primary(['permission_id', 'role_id']);
-            });
+            $table->primary(['permission_id', 'role_id']);
         });
     }
 
@@ -85,12 +78,12 @@ class CreatePermissionTables extends Migration
      */
     public function down()
     {
-        $config = config('laravel-permission.table_names');
+        $tableNames = config('permission.table_names');
 
-        Schema::drop($config['role_has_permissions']);
-        Schema::drop($config['user_has_roles']);
-        Schema::drop($config['user_has_permissions']);
-        Schema::drop($config['roles']);
-        Schema::drop($config['permissions']);
+        Schema::drop($tableNames['role_has_permissions']);
+        Schema::drop($tableNames['model_has_roles']);
+        Schema::drop($tableNames['model_has_permissions']);
+        Schema::drop($tableNames['roles']);
+        Schema::drop($tableNames['permissions']);
     }
 }


### PR DESCRIPTION
We are using the latest version of `laravel-permission` in production. These are the required changes to make Backpack Permissons work with this version. 

The changes here are relatively small. The bigger issue is probably the upgrade strategy and documenting how to upgrade. The reason for that is the change from attaching roles and permission to a user to any model through the [morph feature](https://laravel.com/docs/5.4/eloquent-relationships#polymorphic-relations) of Laravel. 

What do you think about the upgrade? 