### PR TITLE
Fix 'Class CRUD not found' bug

### DIFF
--- a/src/PermissionManagerServiceProvider.php
+++ b/src/PermissionManagerServiceProvider.php
@@ -30,6 +30,9 @@ class PermissionManagerServiceProvider extends ServiceProvider
      */
     public function boot()
     {
+        // define the routes for the application
+        $this->setupRoutes($this->app->router);
+
         // use the vendor configuration file as fallback
         $this->mergeConfigFrom(
             __DIR__.'/config/laravel-permission.php', 'laravel-permission'
@@ -75,8 +78,6 @@ class PermissionManagerServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->setupRoutes($this->app->router);
-
         $this->app->register(PermissionServiceProvider::class);
     }
 }


### PR DESCRIPTION
Similar to https://github.com/Laravel-Backpack/Settings/pull/65

Sometimes, we have this bug:

> In permissionmanager.php line 18: 
> Class 'CRUD' not found

This bug appears when PermissionManager is registered before CRUD. 
With Laravel 5.5 Packages autodiscovery, we can't know in which order the packages `register` methods are called.

Laravel documentation mentions this:

> You should never attempt to register any event listeners, routes, or any other piece of functionality within the register method. Otherwise, you may accidentally use a service that is provided by a service provider which has not loaded yet.

https://laravel.com/docs/5.5/providers