### PR TITLE
Clears permissions cache, otherwise, user won't notice changes

### DIFF
--- a/src/app/Http/Controllers/PermissionCrudController.php
+++ b/src/app/Http/Controllers/PermissionCrudController.php
@@ -3,9 +3,9 @@
 namespace Backpack\PermissionManager\app\Http\Controllers;
 
 use Backpack\CRUD\app\Http\Controllers\CrudController;
-// VALIDATION
 use Backpack\PermissionManager\app\Http\Requests\PermissionCrudRequest as StoreRequest;
 use Backpack\PermissionManager\app\Http\Requests\PermissionCrudRequest as UpdateRequest;
+use Spatie\Permission\PermissionRegistrar;
 
 class PermissionCrudController extends CrudController
 {
@@ -58,11 +58,15 @@ class PermissionCrudController extends CrudController
 
     public function store(StoreRequest $request)
     {
-        return parent::storeCrud();
+        $response=parent::storeCrud();
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
+        return $response;
     }
 
     public function update(UpdateRequest $request)
     {
-        return parent::updateCrud();
+        $response=parent::updateCrud();
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
+        return $response;
     }
 }

--- a/src/app/Http/Controllers/RoleCrudController.php
+++ b/src/app/Http/Controllers/RoleCrudController.php
@@ -3,9 +3,9 @@
 namespace Backpack\PermissionManager\app\Http\Controllers;
 
 use Backpack\CRUD\app\Http\Controllers\CrudController;
-// VALIDATION
 use Backpack\PermissionManager\app\Http\Requests\RoleCrudRequest as StoreRequest;
 use Backpack\PermissionManager\app\Http\Requests\RoleCrudRequest as UpdateRequest;
+use Spatie\Permission\PermissionRegistrar;
 
 class RoleCrudController extends CrudController
 {
@@ -61,17 +61,15 @@ class RoleCrudController extends CrudController
 
     public function store(StoreRequest $request)
     {
-        //otherwise, changes won't have effect
-        \Cache::forget('spatie.permission.cache');
-
-        return parent::storeCrud();
+        $response= parent::storeCrud();
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
+        return $response;
     }
 
     public function update(UpdateRequest $request)
     {
-        //otherwise, changes won't have effect
-        \Cache::forget('spatie.permission.cache');
-
-        return parent::updateCrud();
+        $response= parent::updateCrud();
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
+        return $response;
     }
 }

--- a/src/app/Http/Controllers/UserCrudController.php
+++ b/src/app/Http/Controllers/UserCrudController.php
@@ -6,6 +6,7 @@ use Backpack\CRUD\app\Http\Controllers\CrudController;
 use Backpack\CRUD\app\Http\Requests\CrudRequest;
 use Backpack\PermissionManager\app\Http\Requests\UserStoreCrudRequest as StoreRequest;
 use Backpack\PermissionManager\app\Http\Requests\UserUpdateCrudRequest as UpdateRequest;
+use Spatie\Permission\PermissionRegistrar;
 
 class UserCrudController extends CrudController
 {
@@ -116,7 +117,9 @@ class UserCrudController extends CrudController
     {
         $this->handlePasswordInput($request);
 
-        return parent::storeCrud($request);
+        $response=parent::storeCrud($request);
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
+        return $response;
     }
 
     /**
@@ -130,7 +133,9 @@ class UserCrudController extends CrudController
     {
         $this->handlePasswordInput($request);
 
-        return parent::updateCrud($request);
+        $response=parent::updateCrud($request);
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
+        return $response;
     }
 
     /**


### PR DESCRIPTION
Fixes: 
when permissions / roles / users change, nothing happens unless cache is cleared.

**Feels like the module doesn't work**

This is taken care automatically when using Permission object, but backpack uses CrudController, so we need to clear manually on 
role store/update 
permission store/update
user store/update

Note: 
@lloy0076 
@tabacitu 
It may be needed for "destroy" method, but I don't know if we can safely override destroy method in crudcontroller  
