### PR TITLE
spatie/laravel-permission bump from ^1.4 to ^2.7 (breaking change)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         }
     ],
     "require": {
-        "spatie/laravel-permission": "^1.4",
+        "spatie/laravel-permission": "^2.7",
         "backpack/crud": "^3.3.0"
     },
     "require-dev": {

--- a/src/app/Models/Permission.php
+++ b/src/app/Models/Permission.php
@@ -9,5 +9,5 @@ class Permission extends OriginalPermission
 {
     use CrudTrait;
 
-    protected $fillable = ['name', 'updated_at', 'created_at'];
+    protected $fillable = ['name', 'guard_name', 'updated_at', 'created_at'];
 }

--- a/src/app/Models/Role.php
+++ b/src/app/Models/Role.php
@@ -9,5 +9,5 @@ class Role extends OriginalRole
 {
     use CrudTrait;
 
-    protected $fillable = ['name', 'updated_at', 'created_at'];
+    protected $fillable = ['name', 'guard_name', 'updated_at', 'created_at'];
 }

--- a/src/config/laravel-permission.php
+++ b/src/config/laravel-permission.php
@@ -2,15 +2,15 @@
 
 return [
 
-    /*
-    |--------------------------------------------------------------------------
-    | Authorization Models
-    |--------------------------------------------------------------------------
-    */
+	/*
+	|--------------------------------------------------------------------------
+	| Authorization Models
+	|--------------------------------------------------------------------------
+	*/
 
-    'models' => [
+	'models' => [
 
-        /*
+		/*
         |--------------------------------------------------------------------------
         | Permission Model
         |--------------------------------------------------------------------------
@@ -22,11 +22,11 @@ return [
         | The model you want to use as a Permission model needs to implement the
         | `Spatie\Permission\Contracts\Permission` contract.
         |
-        */
+		 */
 
-        'permission' => Backpack\PermissionManager\app\Models\Permission::class,
+		'permission' => Backpack\PermissionManager\app\Models\Permission::class,
 
-        /*
+		/*
         |--------------------------------------------------------------------------
         | Role Model
         |--------------------------------------------------------------------------
@@ -38,21 +38,21 @@ return [
         | The model you want to use as a Role model needs to implement the
         | `Spatie\Permission\Contracts\Role` contract.
         |
-        */
+		 */
 
-        'role' => Backpack\PermissionManager\app\Models\Role::class,
+		'role' => Backpack\PermissionManager\app\Models\Role::class,
 
-    ],
+	],
 
-    /*
-    |--------------------------------------------------------------------------
-    | Authorization Tables
-    |--------------------------------------------------------------------------
-    */
+	/*
+	|--------------------------------------------------------------------------
+	| Authorization Tables
+	|--------------------------------------------------------------------------
+	*/
 
-    'table_names' => [
+	'table_names' => [
 
-        /*
+		/*
         |--------------------------------------------------------------------------
         | Users Table
         |--------------------------------------------------------------------------
@@ -60,10 +60,10 @@ return [
         | The table that your application uses for users. This table's model will
         | be using the "HasRoles" and "HasPermissions" traits.
         |
-        */
-        'users' => 'users',
+		 */
+		'users' => 'users',
 
-        /*
+		/*
         |--------------------------------------------------------------------------
         | Roles Table
         |--------------------------------------------------------------------------
@@ -72,11 +72,11 @@ return [
         | table should be used to retrieve your roles. We have chosen a basic
         | default value but you may easily change it to any table you like.
         |
-        */
+		 */
 
-        'roles' => 'roles',
+		'roles' => 'roles',
 
-        /*
+		/*
         |--------------------------------------------------------------------------
         | Permissions Table
         |--------------------------------------------------------------------------
@@ -85,49 +85,54 @@ return [
         | table should be used to retrieve your permissions. We have chosen a basic
         | default value but you may easily change it to any table you like.
         |
-        */
+		 */
 
-        'permissions' => 'permissions',
+		'permissions' => 'permissions',
 
-        /*
+		/*
         |--------------------------------------------------------------------------
         | User Permissions Table
         |--------------------------------------------------------------------------
         |
         | When using the "HasRoles" trait from this package, we need to know which
-        | table should be used to retrieve your users permissions. We have chosen a
+        | table should be used to retrieve your models permissions. We have chosen a
         | basic default value but you may easily change it to any table you like.
         |
-        */
+		 */
 
-        'user_has_permissions' => 'permission_users',
+		'model_has_permissions' => 'model_has_permissions',
 
-        /*
-        |--------------------------------------------------------------------------
-        | User Roles Table
-        |--------------------------------------------------------------------------
-        |
-        | When using the "HasRoles" trait from this package, we need to know which
-        | table should be used to retrieve your users roles. We have chosen a
-        | basic default value but you may easily change it to any table you like.
-        |
-        */
+		/*
+		|--------------------------------------------------------------------------
+		| User Roles Table
+		|--------------------------------------------------------------------------
+		|
+		| When using the "HasRoles" trait from this package, we need to know which
+		| table should be used to retrieve your model roles. We have chosen a
+		| basic default value but you may easily change it to any table you like.
+		|
+		*/
 
-        'user_has_roles' => 'role_users',
+		'model_has_roles' => 'model_has_roles',
 
-        /*
-        |--------------------------------------------------------------------------
-        | Role Permissions Table
-        |--------------------------------------------------------------------------
-        |
-        | When using the "HasRoles" trait from this package, we need to know which
-        | table should be used to retrieve your roles permissions. We have chosen a
-        | basic default value but you may easily change it to any table you like.
-        |
-        */
+		/*
+		|--------------------------------------------------------------------------
+		| Role Permissions Table
+		|--------------------------------------------------------------------------
+		|
+		| When using the "HasRoles" trait from this package, we need to know which
+		| table should be used to retrieve your roles permissions. We have chosen a
+		| basic default value but you may easily change it to any table you like.
+		|
+		*/
 
-        'role_has_permissions' => 'permission_roles',
+		'role_has_permissions' => 'role_has_permissions',
+	],
 
-    ],
+	/*
+	 * By default all permissions will be cached for 24 hours unless a permission or
+	 * role is updated. Then the cache will be flushed immediately.
+	 */
 
+	'cache_expiration_time' => 60 * 24,
 ];

--- a/src/database/migrations/2016_05_10_130540_create_permission_tables.php
+++ b/src/database/migrations/2016_05_10_130540_create_permission_tables.php
@@ -12,7 +12,7 @@ class CreatePermissionTables extends Migration
 	 */
 	public function up()
 	{
-		$tableNames = config('permission.table_names');
+		$tableNames = config('laravel-permission.table_names');
 
 		Schema::create($tableNames['permissions'], function (Blueprint $table) {
 			$table->increments('id');
@@ -79,7 +79,7 @@ class CreatePermissionTables extends Migration
 	 */
 	public function down()
 	{
-		$tableNames = config('permission.table_names');
+		$tableNames = config('laravel-permission.table_names');
 
 		Schema::drop($tableNames['role_has_permissions']);
 		Schema::drop($tableNames['model_has_roles']);


### PR DESCRIPTION
Upgraded because I needed this: [spatie/laravel-permission#using-multiple-guards](https://github.com/spatie/laravel-permission/tree/2.7.6#using-multiple-guards).

- Updated migrations file from spatie/laravel-permission
- Updated models (added table fields that are new in new migration file)

It works as expected in fresh backapack+PermissionManager install.