### PR TITLE
Fix #144 - using custom Role and Permission model everywhere

### DIFF
--- a/src/app/Http/Controllers/PermissionCrudController.php
+++ b/src/app/Http/Controllers/PermissionCrudController.php
@@ -11,7 +11,10 @@ class PermissionCrudController extends CrudController
 {
     public function setup()
     {
-        $this->crud->setModel(config('laravel-permission.models.permission'));
+        $role_model = config('laravel-permission.models.role');
+        $permission_model = config('laravel-permission.models.permission');
+
+        $this->crud->setModel($permission_model);
         $this->crud->setEntityNameStrings(trans('backpack::permissionmanager.permission_singular'), trans('backpack::permissionmanager.permission_plural'));
         $this->crud->setRoute(config('backpack.base.route_prefix').'/permission');
 
@@ -26,7 +29,7 @@ class PermissionCrudController extends CrudController
             'name'      => 'roles',
             'entity'    => 'roles',
             'attribute' => 'name',
-            'model'     => "Backpack\PermissionManager\app\Models\Role",
+            'model'     => $role_model,
             'pivot'     => true,
         ]);
 
@@ -41,7 +44,7 @@ class PermissionCrudController extends CrudController
             'name'      => 'roles',
             'entity'    => 'roles',
             'attribute' => 'name',
-            'model'     => "Backpack\PermissionManager\app\Models\Role",
+            'model'     => $role_model,
             'pivot'     => true,
         ]);
 

--- a/src/app/Http/Controllers/RoleCrudController.php
+++ b/src/app/Http/Controllers/RoleCrudController.php
@@ -11,7 +11,10 @@ class RoleCrudController extends CrudController
 {
     public function setup()
     {
-        $this->crud->setModel(config('laravel-permission.models.role'));
+        $role_model = config('laravel-permission.models.role');
+        $permission_model = config('laravel-permission.models.permission');
+
+        $this->crud->setModel($role_model);
         $this->crud->setEntityNameStrings(trans('backpack::permissionmanager.role'), trans('backpack::permissionmanager.roles'));
         $this->crud->setRoute(config('backpack.base.route_prefix').'/role');
 
@@ -28,7 +31,7 @@ class RoleCrudController extends CrudController
                 'name'      => 'permissions', // the method that defines the relationship in your Model
                 'entity'    => 'permissions', // the method that defines the relationship in your Model
                 'attribute' => 'name', // foreign key attribute that is shown to user
-                'model'     => "Backpack\PermissionManager\app\Models\Permission", // foreign key model
+                'model'     => $permission_model, // foreign key model
                 'pivot'     => true, // on create&update, do you need to add/delete pivot table entries?
             ],
         ]);
@@ -44,7 +47,7 @@ class RoleCrudController extends CrudController
             'name'      => 'permissions',
             'entity'    => 'permissions',
             'attribute' => 'name',
-            'model'     => "Backpack\PermissionManager\app\Models\Permission",
+            'model'     => $permission_model,
             'pivot'     => true,
         ]);
 


### PR DESCRIPTION
This PR makes sure the fields and columns also use custom Role and Permission models, as defined in the ```laravel-permission.php``` config file.