### PR TITLE
update routes/backpack/permissionmanager.php middleware to use backpack_middleware()

### DIFF
--- a/src/routes/backpack/permissionmanager.php
+++ b/src/routes/backpack/permissionmanager.php
@@ -13,7 +13,7 @@
 Route::group([
             'namespace'  => 'Backpack\PermissionManager\app\Http\Controllers',
             'prefix'     => config('backpack.base.route_prefix', 'admin'),
-            'middleware' => ['web', 'admin'],
+            'middleware' => ['web', backpack_middleware()],
     ], function () {
         CRUD::resource('permission', 'PermissionCrudController');
         CRUD::resource('role', 'RoleCrudController');


### PR DESCRIPTION
The 'admin' middleware hardcoded in routes/backpack/permissionmanager.php breaks when the user changes the middleware key in config/backpack/base.php.

This PR changes the 'admin' middleware to reference the backpack_middleware() helper funciton.

Fixes #150 