### PR TITLE
spatie/laravel-permission v2.12 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ An admin interface to easily add/edit/remove users, roles and permissions, using
 - a user can have multiple roles;
 - a user can have extra permissions, in addition to the permissions on the roles he has;
 
+This package is just a user interface for [spatie/laravel-permission](https://github.com/spatie/laravel-permission). It will install it, and let you use its API in code. Please refer to their README for more information on how to use in code.
+
 ![Edit a user in Backpack/PermissionManager](https://backpackforlaravel.com/uploads/screenshots/permissions_users_edit.png)
 
 
@@ -25,7 +27,7 @@ An admin interface to easily add/edit/remove users, roles and permissions, using
 1) In your terminal:
 
 ``` bash
-$ composer require backpack/permissionmanager
+composer require backpack/permissionmanager
 ```
 
 2) Publish the config file & run the migrations
@@ -52,16 +54,16 @@ class User extends Authenticatable
      */
 ```
 
-4) [Optional] Add a menu item for it in resources/views/vendor/backpack/base/inc/sidebar_content.blade.php or menu.blade.php:
+4) [Optional] Add a menu item for it in ```resources/views/vendor/backpack/base/inc/sidebar_content.blade.php``` or ```menu.blade.php```:
 
 ```html
 <!-- Users, Roles Permissions -->
   <li class="treeview">
     <a href="#"><i class="fa fa-group"></i> <span>Users, Roles, Permissions</span> <i class="fa fa-angle-left pull-right"></i></a>
     <ul class="treeview-menu">
-      <li><a href="{{ url(config('backpack.base.route_prefix', 'admin') . '/user') }}"><i class="fa fa-user"></i> <span>Users</span></a></li>
-      <li><a href="{{ url(config('backpack.base.route_prefix', 'admin') . '/role') }}"><i class="fa fa-group"></i> <span>Roles</span></a></li>
-      <li><a href="{{ url(config('backpack.base.route_prefix', 'admin') . '/permission') }}"><i class="fa fa-key"></i> <span>Permissions</span></a></li>
+      <li><a href="{{ backpack_url('user') }}"><i class="fa fa-user"></i> <span>Users</span></a></li>
+      <li><a href="{{ backpack_url('role') }}"><i class="fa fa-group"></i> <span>Roles</span></a></li>
+      <li><a href="{{ backpack_url('permission') }}"><i class="fa fa-key"></i> <span>Permissions</span></a></li>
     </ul>
   </li>
 ```
@@ -71,7 +73,7 @@ class User extends Authenticatable
 
 ## API Usage
 
-Because the package requires [spatie/laravel-permission](https://github.com/spatie/laravel-permission), the API will be the same: 
+Because the package requires [spatie/laravel-permission](https://github.com/spatie/laravel-permission), the API will be the same. Please refer to their README file for a complete API. Here's a summary though:
 
 ### Using permissions
 
@@ -170,6 +172,9 @@ You can use Laravels native @can directive to check if a user has a certain perm
 
 Please see [CHANGELOG](CHANGELOG.md) for more information what has changed recently.
 
+## Upgrade guide
+
+On June 7th 2018 we've upgraded from using ```spatie/laravel-permission``` 1.4 to 2.12. The changes in our package have been minor. But in their package they have been massive - including a different database schema. They have provided no upgrade guide for going from 1.x to 2.x. We have not developed such a guide either. If/when we do, we'll link it here. Our 2 cents: use the 1.x version if it works for you, and you don't need any new features. The hassle of changing all you database structure is not worth it.
 
 ## Screenshots
 

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         }
     ],
     "require": {
-        "spatie/laravel-permission": "^2.12",
+        "spatie/laravel-permission": "^2.12.0",
         "backpack/crud": "^3.4.0"
     },
     "require-dev": {

--- a/src/PermissionManagerServiceProvider.php
+++ b/src/PermissionManagerServiceProvider.php
@@ -35,7 +35,7 @@ class PermissionManagerServiceProvider extends ServiceProvider
 
         // use the vendor configuration file as fallback
         $this->mergeConfigFrom(
-            __DIR__.'/config/laravel-permission.php', 'laravel-permission'
+            __DIR__.'/config/permission.php', 'permission'
         );
         $this->mergeConfigFrom(
             __DIR__.'/config/backpack/permissionmanager.php', 'backpack.permissionmanager'

--- a/src/app/Http/Controllers/PermissionCrudController.php
+++ b/src/app/Http/Controllers/PermissionCrudController.php
@@ -11,8 +11,8 @@ class PermissionCrudController extends CrudController
 {
     public function setup()
     {
-        $role_model = config('laravel-permission.models.role');
-        $permission_model = config('laravel-permission.models.permission');
+        $role_model = config('permission.models.role');
+        $permission_model = config('permission.models.permission');
 
         $this->crud->setModel($permission_model);
         $this->crud->setEntityNameStrings(trans('backpack::permissionmanager.permission_singular'), trans('backpack::permissionmanager.permission_plural'));

--- a/src/app/Http/Controllers/RoleCrudController.php
+++ b/src/app/Http/Controllers/RoleCrudController.php
@@ -11,8 +11,8 @@ class RoleCrudController extends CrudController
 {
     public function setup()
     {
-        $role_model = config('laravel-permission.models.role');
-        $permission_model = config('laravel-permission.models.permission');
+        $role_model = config('permission.models.role');
+        $permission_model = config('permission.models.permission');
 
         $this->crud->setModel($role_model);
         $this->crud->setEntityNameStrings(trans('backpack::permissionmanager.role'), trans('backpack::permissionmanager.roles'));

--- a/src/app/Http/Controllers/UserCrudController.php
+++ b/src/app/Http/Controllers/UserCrudController.php
@@ -16,10 +16,9 @@ class UserCrudController extends CrudController
         | BASIC CRUD INFORMATION
         |--------------------------------------------------------------------------
         */
-        $this->crud->setModel(config('backpack.permissionmanager.user_model'));
+        $this->crud->setModel(config('backpack.base.user_model_fqn'));
         $this->crud->setEntityNameStrings(trans('backpack::permissionmanager.user'), trans('backpack::permissionmanager.users'));
         $this->crud->setRoute(config('backpack.base.route_prefix').'/user');
-        $this->crud->enableAjaxTable();
 
         // Columns.
         $this->crud->setColumns([
@@ -39,7 +38,7 @@ class UserCrudController extends CrudController
                'name'      => 'roles', // the method that defines the relationship in your Model
                'entity'    => 'roles', // the method that defines the relationship in your Model
                'attribute' => 'name', // foreign key attribute that is shown to user
-               'model'     => config('laravel-permission.models.role'), // foreign key model
+               'model'     => config('permission.models.role'), // foreign key model
             ],
             [ // n-n relationship (with pivot table)
                'label'     => trans('backpack::permissionmanager.extra_permissions'), // Table column heading
@@ -47,7 +46,7 @@ class UserCrudController extends CrudController
                'name'      => 'permissions', // the method that defines the relationship in your Model
                'entity'    => 'permissions', // the method that defines the relationship in your Model
                'attribute' => 'name', // foreign key attribute that is shown to user
-               'model'     => config('laravel-permission.models.permission'), // foreign key model
+               'model'     => config('permission.models.permission'), // foreign key model
             ],
         ]);
 
@@ -86,7 +85,7 @@ class UserCrudController extends CrudController
                         'entity'           => 'roles', // the method that defines the relationship in your Model
                         'entity_secondary' => 'permissions', // the method that defines the relationship in your Model
                         'attribute'        => 'name', // foreign key attribute that is shown to user
-                        'model'            => config('laravel-permission.models.role'), // foreign key model
+                        'model'            => config('permission.models.role'), // foreign key model
                         'pivot'            => true, // on create&update, do you need to add/delete pivot table entries?]
                         'number_columns'   => 3, //can be 1,2,3,4,6
                     ],
@@ -96,7 +95,7 @@ class UserCrudController extends CrudController
                         'entity'         => 'permissions', // the method that defines the relationship in your Model
                         'entity_primary' => 'roles', // the method that defines the relationship in your Model
                         'attribute'      => 'name', // foreign key attribute that is shown to user
-                        'model'          => config('laravel-permission.models.permission'), // foreign key model
+                        'model'          => config('permission.models.permission'), // foreign key model
                         'pivot'          => true, // on create&update, do you need to add/delete pivot table entries?]
                         'number_columns' => 3, //can be 1,2,3,4,6
                     ],

--- a/src/app/Http/Requests/UserStoreCrudRequest.php
+++ b/src/app/Http/Requests/UserStoreCrudRequest.php
@@ -14,7 +14,7 @@ class UserStoreCrudRequest extends CrudRequest
     public function rules()
     {
         return [
-            'email'    => 'required|unique:'.config('laravel-permission.table_names.users', 'users').',email',
+            'email'    => 'required|unique:'.config('permission.table_names.users', 'users').',email',
             'name'     => 'required',
             'password' => 'required|confirmed',
         ];

--- a/src/config/backpack/permissionmanager.php
+++ b/src/config/backpack/permissionmanager.php
@@ -8,14 +8,6 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | User Fully-Qualified Class Name
-    |--------------------------------------------------------------------------
-    |
-    */
-    'user_model' => 'App\User',
-
-    /*
-    |--------------------------------------------------------------------------
     | Disallow the user interface for creating/updating permissions or roles.
     |--------------------------------------------------------------------------
     | Roles and permissions are used in code by their name

--- a/src/config/laravel-permission.php
+++ b/src/config/laravel-permission.php
@@ -2,15 +2,15 @@
 
 return [
 
-	/*
-	|--------------------------------------------------------------------------
-	| Authorization Models
-	|--------------------------------------------------------------------------
-	*/
+    /*
+    |--------------------------------------------------------------------------
+    | Authorization Models
+    |--------------------------------------------------------------------------
+    */
 
-	'models' => [
+    'models' => [
 
-		/*
+        /*
         |--------------------------------------------------------------------------
         | Permission Model
         |--------------------------------------------------------------------------
@@ -22,11 +22,11 @@ return [
         | The model you want to use as a Permission model needs to implement the
         | `Spatie\Permission\Contracts\Permission` contract.
         |
-		 */
+         */
 
-		'permission' => Backpack\PermissionManager\app\Models\Permission::class,
+        'permission' => Backpack\PermissionManager\app\Models\Permission::class,
 
-		/*
+        /*
         |--------------------------------------------------------------------------
         | Role Model
         |--------------------------------------------------------------------------
@@ -38,21 +38,21 @@ return [
         | The model you want to use as a Role model needs to implement the
         | `Spatie\Permission\Contracts\Role` contract.
         |
-		 */
+         */
 
-		'role' => Backpack\PermissionManager\app\Models\Role::class,
+        'role' => Backpack\PermissionManager\app\Models\Role::class,
 
-	],
+    ],
 
-	/*
-	|--------------------------------------------------------------------------
-	| Authorization Tables
-	|--------------------------------------------------------------------------
-	*/
+    /*
+    |--------------------------------------------------------------------------
+    | Authorization Tables
+    |--------------------------------------------------------------------------
+    */
 
-	'table_names' => [
+    'table_names' => [
 
-		/*
+        /*
         |--------------------------------------------------------------------------
         | Users Table
         |--------------------------------------------------------------------------
@@ -60,10 +60,10 @@ return [
         | The table that your application uses for users. This table's model will
         | be using the "HasRoles" and "HasPermissions" traits.
         |
-		 */
-		'users' => 'users',
+         */
+        'users' => 'users',
 
-		/*
+        /*
         |--------------------------------------------------------------------------
         | Roles Table
         |--------------------------------------------------------------------------
@@ -72,11 +72,11 @@ return [
         | table should be used to retrieve your roles. We have chosen a basic
         | default value but you may easily change it to any table you like.
         |
-		 */
+         */
 
-		'roles' => 'roles',
+        'roles' => 'roles',
 
-		/*
+        /*
         |--------------------------------------------------------------------------
         | Permissions Table
         |--------------------------------------------------------------------------
@@ -85,11 +85,11 @@ return [
         | table should be used to retrieve your permissions. We have chosen a basic
         | default value but you may easily change it to any table you like.
         |
-		 */
+         */
 
-		'permissions' => 'permissions',
+        'permissions' => 'permissions',
 
-		/*
+        /*
         |--------------------------------------------------------------------------
         | User Permissions Table
         |--------------------------------------------------------------------------
@@ -98,41 +98,41 @@ return [
         | table should be used to retrieve your models permissions. We have chosen a
         | basic default value but you may easily change it to any table you like.
         |
-		 */
+         */
 
-		'model_has_permissions' => 'model_has_permissions',
+        'model_has_permissions' => 'model_has_permissions',
 
-		/*
-		|--------------------------------------------------------------------------
-		| User Roles Table
-		|--------------------------------------------------------------------------
-		|
-		| When using the "HasRoles" trait from this package, we need to know which
-		| table should be used to retrieve your model roles. We have chosen a
-		| basic default value but you may easily change it to any table you like.
-		|
-		*/
+        /*
+        |--------------------------------------------------------------------------
+        | User Roles Table
+        |--------------------------------------------------------------------------
+        |
+        | When using the "HasRoles" trait from this package, we need to know which
+        | table should be used to retrieve your model roles. We have chosen a
+        | basic default value but you may easily change it to any table you like.
+        |
+        */
 
-		'model_has_roles' => 'model_has_roles',
+        'model_has_roles' => 'model_has_roles',
 
-		/*
-		|--------------------------------------------------------------------------
-		| Role Permissions Table
-		|--------------------------------------------------------------------------
-		|
-		| When using the "HasRoles" trait from this package, we need to know which
-		| table should be used to retrieve your roles permissions. We have chosen a
-		| basic default value but you may easily change it to any table you like.
-		|
-		*/
+        /*
+        |--------------------------------------------------------------------------
+        | Role Permissions Table
+        |--------------------------------------------------------------------------
+        |
+        | When using the "HasRoles" trait from this package, we need to know which
+        | table should be used to retrieve your roles permissions. We have chosen a
+        | basic default value but you may easily change it to any table you like.
+        |
+        */
 
-		'role_has_permissions' => 'role_has_permissions',
-	],
+        'role_has_permissions' => 'role_has_permissions',
+    ],
 
-	/*
-	 * By default all permissions will be cached for 24 hours unless a permission or
-	 * role is updated. Then the cache will be flushed immediately.
-	 */
+    /*
+     * By default all permissions will be cached for 24 hours unless a permission or
+     * role is updated. Then the cache will be flushed immediately.
+     */
 
-	'cache_expiration_time' => 60 * 24,
+    'cache_expiration_time' => 60 * 24,
 ];

--- a/src/config/permission.php
+++ b/src/config/permission.php
@@ -133,6 +133,11 @@ return [
      * By default all permissions will be cached for 24 hours unless a permission or
      * role is updated. Then the cache will be flushed immediately.
      */
-
     'cache_expiration_time' => 60 * 24,
+    /*
+     * When set to true, the required permission/role names are added to the exception
+     * message. This could be considered an information leak in some contexts, so
+     * the default setting is false here for optimum safety.
+     */
+    'display_permission_in_exception' => false,
 ];

--- a/src/database/migrations/2016_05_10_130540_create_permission_tables.php
+++ b/src/database/migrations/2016_05_10_130540_create_permission_tables.php
@@ -5,86 +5,86 @@ use Illuminate\Database\Schema\Blueprint;
 
 class CreatePermissionTables extends Migration
 {
-	/**
-	 * Run the migrations.
-	 *
-	 * @return void
-	 */
-	public function up()
-	{
-		$tableNames = config('laravel-permission.table_names');
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $tableNames = config('laravel-permission.table_names');
 
-		Schema::create($tableNames['permissions'], function (Blueprint $table) {
-			$table->increments('id');
-			$table->string('name');
-			$table->string('guard_name');
-			$table->timestamps();
-		});
+        Schema::create($tableNames['permissions'], function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->string('guard_name');
+            $table->timestamps();
+        });
 
-		Schema::create($tableNames['roles'], function (Blueprint $table) {
-			$table->increments('id');
-			$table->string('name');
-			$table->string('guard_name');
-			$table->timestamps();
-		});
+        Schema::create($tableNames['roles'], function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->string('guard_name');
+            $table->timestamps();
+        });
 
-		Schema::create($tableNames['model_has_permissions'], function (Blueprint $table) use ($tableNames) {
-			$table->integer('permission_id')->unsigned();
-			$table->morphs('model');
+        Schema::create($tableNames['model_has_permissions'], function (Blueprint $table) use ($tableNames) {
+            $table->integer('permission_id')->unsigned();
+            $table->morphs('model');
 
-			$table->foreign('permission_id')
-				->references('id')
-				->on($tableNames['permissions'])
-				->onDelete('cascade');
+            $table->foreign('permission_id')
+                ->references('id')
+                ->on($tableNames['permissions'])
+                ->onDelete('cascade');
 
-			$table->primary(['permission_id', 'model_id', 'model_type']);
-		});
+            $table->primary(['permission_id', 'model_id', 'model_type']);
+        });
 
-		Schema::create($tableNames['model_has_roles'], function (Blueprint $table) use ($tableNames) {
-			$table->integer('role_id')->unsigned();
-			$table->morphs('model');
+        Schema::create($tableNames['model_has_roles'], function (Blueprint $table) use ($tableNames) {
+            $table->integer('role_id')->unsigned();
+            $table->morphs('model');
 
-			$table->foreign('role_id')
-				->references('id')
-				->on($tableNames['roles'])
-				->onDelete('cascade');
+            $table->foreign('role_id')
+                ->references('id')
+                ->on($tableNames['roles'])
+                ->onDelete('cascade');
 
-			$table->primary(['role_id', 'model_id', 'model_type']);
-		});
+            $table->primary(['role_id', 'model_id', 'model_type']);
+        });
 
-		Schema::create($tableNames['role_has_permissions'], function (Blueprint $table) use ($tableNames) {
-			$table->integer('permission_id')->unsigned();
-			$table->integer('role_id')->unsigned();
+        Schema::create($tableNames['role_has_permissions'], function (Blueprint $table) use ($tableNames) {
+            $table->integer('permission_id')->unsigned();
+            $table->integer('role_id')->unsigned();
 
-			$table->foreign('permission_id')
-				->references('id')
-				->on($tableNames['permissions'])
-				->onDelete('cascade');
+            $table->foreign('permission_id')
+                ->references('id')
+                ->on($tableNames['permissions'])
+                ->onDelete('cascade');
 
-			$table->foreign('role_id')
-				->references('id')
-				->on($tableNames['roles'])
-				->onDelete('cascade');
+            $table->foreign('role_id')
+                ->references('id')
+                ->on($tableNames['roles'])
+                ->onDelete('cascade');
 
-			$table->primary(['permission_id', 'role_id']);
+            $table->primary(['permission_id', 'role_id']);
 
-			Cache::forget('spatie.permission.cache');
-		});
-	}
+            Cache::forget('spatie.permission.cache');
+        });
+    }
 
-	/**
-	 * Reverse the migrations.
-	 *
-	 * @return void
-	 */
-	public function down()
-	{
-		$tableNames = config('laravel-permission.table_names');
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        $tableNames = config('laravel-permission.table_names');
 
-		Schema::drop($tableNames['role_has_permissions']);
-		Schema::drop($tableNames['model_has_roles']);
-		Schema::drop($tableNames['model_has_permissions']);
-		Schema::drop($tableNames['roles']);
-		Schema::drop($tableNames['permissions']);
-	}
+        Schema::drop($tableNames['role_has_permissions']);
+        Schema::drop($tableNames['model_has_roles']);
+        Schema::drop($tableNames['model_has_permissions']);
+        Schema::drop($tableNames['roles']);
+        Schema::drop($tableNames['permissions']);
+    }
 }

--- a/src/database/migrations/2016_05_10_130540_create_permission_tables.php
+++ b/src/database/migrations/2016_05_10_130540_create_permission_tables.php
@@ -12,7 +12,7 @@ class CreatePermissionTables extends Migration
      */
     public function up()
     {
-        $tableNames = config('laravel-permission.table_names');
+        $tableNames = config('permission.table_names');
 
         Schema::create($tableNames['permissions'], function (Blueprint $table) {
             $table->increments('id');
@@ -79,7 +79,7 @@ class CreatePermissionTables extends Migration
      */
     public function down()
     {
-        $tableNames = config('laravel-permission.table_names');
+        $tableNames = config('permission.table_names');
 
         Schema::drop($tableNames['role_has_permissions']);
         Schema::drop($tableNames['model_has_roles']);


### PR DESCRIPTION
Based on https://github.com/Laravel-Backpack/PermissionManager/pull/139 - @tomsb 's excellent work. Thank you @tomsb @thomasbilk and @clarkewing for your PRs and very sorry again for leaving this unattended for so long. Hopefully you guys can [read my full apology and solution here and tell me what you think](https://github.com/Laravel-Backpack/PermissionManager/pull/139#issuecomment-395443718).

Important notes:
- the db structure has changed; because that's what spatie did between v1.4 and v2.12;
- there is no upgrade guide from spatie v1 to spatie v2; and after spending a lot of time on this, I understand why; it would have been _way to difficult_ to create migrations for such an upgrade; especially for big projects, that might have other foreign keys to/from the old tables;
- as such, we didn't provide an upgrade guide either; people who use v1 will continue to use v1; people who start now will be using v2;
- if we do go through the upgrade ourselves at one point, we might provide an upgrade guide; if anybody, ever, creates an upgrade guide, please link to it on the README; 
- since spatie/laravel-permission pushes breaking changes like crazy, and this package is pretty simple and does not need regular updates, I've decided to track spatie/laravel-permission's version; starting now; this new version will be 2.12 because it uses spatie/laravel-permission v2.12;

Thank you everybody for the help.
Cheers!