### PR TITLE
Allow for use of custom guard on request.

### DIFF
--- a/src/app/Http/Requests/PermissionCrudRequest.php
+++ b/src/app/Http/Requests/PermissionCrudRequest.php
@@ -14,7 +14,7 @@ class PermissionCrudRequest extends FormRequest
     public function authorize()
     {
         // only allow updates if the user is logged in
-        return \Auth::check();
+	    return backpack_auth()->check();
     }
 
     /**

--- a/src/app/Http/Requests/RoleCrudRequest.php
+++ b/src/app/Http/Requests/RoleCrudRequest.php
@@ -14,7 +14,7 @@ class RoleCrudRequest extends FormRequest
     public function authorize()
     {
         // only allow updates if the user is logged in
-        return \Auth::check();
+        return backpack_auth()->check();
     }
 
     /**

--- a/src/app/Http/Requests/UserStoreCrudRequest.php
+++ b/src/app/Http/Requests/UserStoreCrudRequest.php
@@ -2,10 +2,21 @@
 
 namespace Backpack\PermissionManager\app\Http\Requests;
 
-use Backpack\CRUD\app\Http\Requests\CrudRequest;
+use Illuminate\Foundation\Http\FormRequest;
 
-class UserStoreCrudRequest extends CrudRequest
+class UserStoreCrudRequest extends FormRequest
 {
+	/**
+	 * Determine if the user is authorized to make this request.
+	 *
+	 * @return bool
+	 */
+	public function authorize()
+	{
+		// only allow updates if the user is logged in
+		return backpack_auth()->check();
+	}
+
     /**
      * Get the validation rules that apply to the request.
      *

--- a/src/app/Http/Requests/UserUpdateCrudRequest.php
+++ b/src/app/Http/Requests/UserUpdateCrudRequest.php
@@ -2,10 +2,21 @@
 
 namespace Backpack\PermissionManager\app\Http\Requests;
 
-use Backpack\CRUD\app\Http\Requests\CrudRequest;
+use Illuminate\Foundation\Http\FormRequest;
 
-class UserUpdateCrudRequest extends CrudRequest
+class UserUpdateCrudRequest extends FormRequest
 {
+	/**
+	 * Determine if the user is authorized to make this request.
+	 *
+	 * @return bool
+	 */
+	public function authorize()
+	{
+		// only allow updates if the user is logged in
+		return backpack_auth()->check();
+	}
+
     /**
      * Get the validation rules that apply to the request.
      *


### PR DESCRIPTION
Set RoleCrudRequest, PermissionCrudRequest, UserStoreCrudRequest and UserUpdateCrudRequest to use the `backpack_auth()` helper in the authorize function. Removed deprecated CrudRequest from UserStoreCrudRequest and UserUpdateCrudRequest.