### PR TITLE
Add french canadien translation

### DIFF
--- a/src/resources/lang/fr_CA/permissionmanager.php
+++ b/src/resources/lang/fr_CA/permissionmanager.php
@@ -1,0 +1,29 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Permission Manager Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used for Laravel Backpack - Permission Manager
+    | Author: Julien Cauvin <contact@7ute.fr>
+    |
+    */
+    'name'                  => 'Nom',
+    'role'                  => 'Rôle',
+    'roles'                 => 'Rôles',
+    'roles_have_permission' => 'Rôles avec cette permission',
+    'permission_singular'   => 'permission',
+    'permission_plural'     => 'permissions',
+    'user_singular'         => 'Utilisateur',
+    'user_plural'           => 'Utilisateurs',
+    'email'                 => 'Email',
+    'extra_permissions'     => 'Permissions supplémentaires',
+    'password'              => 'Mot de passe',
+    'password_confirmation' => 'Confirmation du mot de passe',
+    'user_role_permission'  => 'Rôles et permissions d’utilisateur',
+    'user'                  => 'Utilisateur',
+    'users'                 => 'Utilisateurs',
+
+];


### PR DESCRIPTION
This is a pull request with Translation strings for french canadien language.
I started from french translation array.
My app need to support both french and french canadian translation.
Without fr_CA folder,  translation is missing in the app.