### PR TITLE
Guards for individual roles.

### DIFF
--- a/src/app/Http/Controllers/PermissionCrudController.php
+++ b/src/app/Http/Controllers/PermissionCrudController.php
@@ -4,33 +4,46 @@ namespace Backpack\PermissionManager\app\Http\Controllers;
 
 use Backpack\CRUD\app\Http\Controllers\CrudController;
 // VALIDATION
-use Backpack\PermissionManager\app\Http\Requests\PermissionCrudRequest as StoreRequest;
-use Backpack\PermissionManager\app\Http\Requests\PermissionCrudRequest as UpdateRequest;
+use Backpack\PermissionManager\app\Http\Requests\RoleCrudRequest as StoreRequest;
+use Backpack\PermissionManager\app\Http\Requests\RoleCrudRequest as UpdateRequest;
 
-class PermissionCrudController extends CrudController
+class RoleCrudController extends CrudController
 {
     public function setup()
     {
-        $role_model = config('laravel-permission.models.role');
-        $permission_model = config('laravel-permission.models.permission');
+        $role_model = config('permission.models.role');
+        $permission_model = config('permission.models.permission');
 
-        $this->crud->setModel($permission_model);
-        $this->crud->setEntityNameStrings(trans('backpack::permissionmanager.permission_singular'), trans('backpack::permissionmanager.permission_plural'));
-        $this->crud->setRoute(config('backpack.base.route_prefix').'/permission');
+        $this->crud->setModel($role_model);
+        $this->crud->setEntityNameStrings(trans('backpack::permissionmanager.role'), trans('backpack::permissionmanager.roles'));
+        $this->crud->setRoute(config('backpack.base.route_prefix').'/role');
 
-        $this->crud->addColumn([
-            'name'  => 'name',
-            'label' => trans('backpack::permissionmanager.name'),
-            'type'  => 'text',
-        ]);
-        $this->crud->addColumn([ // n-n relationship (with pivot table)
-            'label'     => trans('backpack::permissionmanager.roles_have_permission'),
-            'type'      => 'select_multiple',
-            'name'      => 'roles',
-            'entity'    => 'roles',
-            'attribute' => 'name',
-            'model'     => $role_model,
-            'pivot'     => true,
+        $this->crud->setColumns([
+            [
+                'name'  => 'name',
+                'label' => trans('backpack::permissionmanager.name'),
+                'type'  => 'text',
+            ],
+            [
+                'name'  => 'guard_name',
+                'label' => trans('backpack::permissionmanager.guard_type'),
+                'type'  => 'text',
+            ],
+            [
+                'name'  => 'guard_name',
+                'label' => trans('backpack::permissionmanager.guard_type'),
+                'type' => 'text',
+            ],
+            [
+                // n-n relationship (with pivot table)
+                'label'     => ucfirst(trans('backpack::permissionmanager.permission_plural')),
+                'type'      => 'select_multiple',
+                'name'      => 'permissions', // the method that defines the relationship in your Model
+                'entity'    => 'permissions', // the method that defines the relationship in your Model
+                'attribute' => 'name', // foreign key attribute that is shown to user
+                'model'     => $permission_model, // foreign key model
+                'pivot'     => true, // on create&update, do you need to add/delete pivot table entries?
+            ],
         ]);
 
         $this->crud->addField([
@@ -38,34 +51,64 @@ class PermissionCrudController extends CrudController
             'label' => trans('backpack::permissionmanager.name'),
             'type'  => 'text',
         ]);
+
         $this->crud->addField([
-            'label'     => trans('backpack::permissionmanager.roles'),
+            'name'  => 'guard_name',
+            'label' => trans('backpack::permissionmanager.guard_type'),
+            'type' => 'select_from_array',
+            'options' => $this->getGuardTypes(),
+        ]);
+        $this->crud->addField([
+            'label'     => ucfirst(trans('backpack::permissionmanager.permission_plural')),
             'type'      => 'checklist',
-            'name'      => 'roles',
-            'entity'    => 'roles',
+            'name'      => 'permissions',
+            'entity'    => 'permissions',
             'attribute' => 'name',
-            'model'     => $role_model,
+            'model'     => $permission_model,
             'pivot'     => true,
         ]);
 
-        if (!config('backpack.permissionmanager.allow_permission_create')) {
+        if (config('backpack.permissionmanager.allow_role_create') == false) {
             $this->crud->denyAccess('create');
         }
-        if (!config('backpack.permissionmanager.allow_permission_update')) {
+        if (config('backpack.permissionmanager.allow_role_update') == false) {
             $this->crud->denyAccess('update');
         }
-        if (!config('backpack.permissionmanager.allow_permission_delete')) {
+        if (config('backpack.permissionmanager.allow_role_delete') == false) {
             $this->crud->denyAccess('delete');
         }
     }
 
     public function store(StoreRequest $request)
     {
+        //otherwise, changes won't have effect
+        \Cache::forget('spatie.permission.cache');
+
         return parent::storeCrud();
     }
 
     public function update(UpdateRequest $request)
     {
+        //otherwise, changes won't have effect
+        \Cache::forget('spatie.permission.cache');
+
         return parent::updateCrud();
+    }
+
+    /*
+     * Get an array list of all available guard types
+     * that have been defined in app/config/auth.php
+     *
+     * @return array
+     **/
+    private function getGuardTypes() {
+      $guards = config('auth.guards');
+
+      $returnable = [];
+      foreach($guards as $key => $details) {
+        $returnable[$key] = $key;
+      }
+
+      return $returnable;
     }
 }

--- a/src/app/Http/Controllers/PermissionCrudController.php
+++ b/src/app/Http/Controllers/PermissionCrudController.php
@@ -7,7 +7,7 @@ use Backpack\CRUD\app\Http\Controllers\CrudController;
 use Backpack\PermissionManager\app\Http\Requests\RoleCrudRequest as StoreRequest;
 use Backpack\PermissionManager\app\Http\Requests\RoleCrudRequest as UpdateRequest;
 
-class RoleCrudController extends CrudController
+class PermissionCrudController extends CrudController
 {
     public function setup()
     {
@@ -32,7 +32,7 @@ class RoleCrudController extends CrudController
             [
                 'name'  => 'guard_name',
                 'label' => trans('backpack::permissionmanager.guard_type'),
-                'type' => 'text',
+                'type'  => 'text',
             ],
             [
                 // n-n relationship (with pivot table)
@@ -53,9 +53,9 @@ class RoleCrudController extends CrudController
         ]);
 
         $this->crud->addField([
-            'name'  => 'guard_name',
-            'label' => trans('backpack::permissionmanager.guard_type'),
-            'type' => 'select_from_array',
+            'name'    => 'guard_name',
+            'label'   => trans('backpack::permissionmanager.guard_type'),
+            'type'    => 'select_from_array',
             'options' => $this->getGuardTypes(),
         ]);
         $this->crud->addField([
@@ -101,14 +101,15 @@ class RoleCrudController extends CrudController
      *
      * @return array
      **/
-    private function getGuardTypes() {
-      $guards = config('auth.guards');
+    private function getGuardTypes()
+    {
+        $guards = config('auth.guards');
 
-      $returnable = [];
-      foreach($guards as $key => $details) {
-        $returnable[$key] = $key;
-      }
+        $returnable = [];
+        foreach ($guards as $key => $details) {
+            $returnable[$key] = $key;
+        }
 
-      return $returnable;
+        return $returnable;
     }
 }

--- a/src/resources/lang/en/permissionmanager.php
+++ b/src/resources/lang/en/permissionmanager.php
@@ -25,5 +25,6 @@ return [
     'user_role_permission'  => 'User Role Permissions',
     'user'                  => 'User',
     'users'                 => 'Users',
+    'guard_type'            => 'Guard Type'
 
 ];

--- a/src/resources/lang/en/permissionmanager.php
+++ b/src/resources/lang/en/permissionmanager.php
@@ -25,6 +25,6 @@ return [
     'user_role_permission'  => 'User Role Permissions',
     'user'                  => 'User',
     'users'                 => 'Users',
-    'guard_type'            => 'Guard Type'
+    'guard_type'            => 'Guard Type',
 
 ];


### PR DESCRIPTION
This allows using the same permissions setup/system both for administrators and front end users who should not be able to see admin stuff. This is built into the new `Spatie/laravel-permission`.

**NOTICE:** This required Laravel-Backpack/PermissionManager 3.12.4 or higher.

It will automatically read all Auth Guards from the `config/auth.php` guard types.

Examples:

<img width="401" alt="screen shot 2018-08-05 at 9 16 13 pm" src="https://user-images.githubusercontent.com/487798/43696867-fb235104-98f4-11e8-985e-6e7ea445f19e.png">
<img width="883" alt="screen shot 2018-08-05 at 9 16 19 pm" src="https://user-images.githubusercontent.com/487798/43696868-fb4135de-98f4-11e8-82d7-38a9a34c9060.png">
