### PR TITLE
Laravel 5.8 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ All Notable changes to `Backpack PermissionManager` will be documented in this f
 - Nothing
 
 
+## [4.0.1] - 2019-02-27
+
+### Added
+- support for the ```upgrade``` branch for Backpack\CRUD, so it can be installed temporarily with Laravel 5.8;
+- requirement for latest version of spatie/laravel-permission, 2.34;
+
+
 ## [4.0.0] - 2018-12-12
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     ],
     "require": {
         "spatie/laravel-permission": "2.28.*",
-        "backpack/crud": "^3.4.0"
+        "backpack/crud": "^3.4.0|dev-upgrade"
     },
     "require-dev": {
         "phpunit/phpunit" : "4.*",

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         }
     ],
     "require": {
-        "spatie/laravel-permission": "2.28.*",
+        "spatie/laravel-permission": "2.34.*",
         "backpack/crud": "^3.4.0|dev-upgrade"
     },
     "require-dev": {


### PR DESCRIPTION
Draft PR. Right now it looks like we'll have to wait for [spatie/laravel-permission](https://github.com/spatie/laravel-permission) to support Laravel 5.8, before we can do anything.