### PR TITLE
Added support for Backpack 4.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     "prefer-stable": true,
     "require": {
         "spatie/laravel-permission": "^3.0",
-        "backpack/crud": "^4.0.0"
+        "backpack/crud": "^4.1.0|^4.0.99"
     },
     "require-dev": {
         "phpunit/phpunit" : "^9.0||^7.0",

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     "prefer-stable": true,
     "require": {
         "spatie/laravel-permission": "^3.0",
-        "backpack/crud": "^4.1.0|^4.0.99"
+        "backpack/crud": "^4.1.0"
     },
     "require-dev": {
         "phpunit/phpunit" : "^9.0||^7.0",

--- a/src/PermissionManagerServiceProvider.php
+++ b/src/PermissionManagerServiceProvider.php
@@ -44,6 +44,9 @@ class PermissionManagerServiceProvider extends ServiceProvider
 
         // publish translation files
         $this->publishes([__DIR__.'/resources/lang' => resource_path('lang/vendor/backpack')], 'lang');
+
+        // publish migration from Backpack 4.0 to Backpack 4.1
+        $this->publishes([__DIR__.'/database/migrations' => database_path('migrations')], 'migrations');
     }
 
     /**

--- a/src/app/Http/Controllers/RoleCrudController.php
+++ b/src/app/Http/Controllers/RoleCrudController.php
@@ -43,6 +43,17 @@ class RoleCrudController extends CrudController
             'label' => trans('backpack::permissionmanager.name'),
             'type'  => 'text',
         ]);
+        $this->crud->addColumn([   // select_multiple: n-n relationship (with pivot table)
+            'label'     => trans('backpack::permissionmanager.users'), // Table column heading
+            'type'      => 'relationship_count',
+            'name'      => 'users', // the method that defines the relationship in your Model
+            'wrapper'   => [
+                'href' => function ($crud, $column, $entry, $related_key) {
+                    return backpack_url('user?role='.$entry->getKey());
+                },
+            ],
+            'suffix'    => ' users',
+        ]);
         if (config('backpack.permissionmanager.multiple_guards')) {
             $this->crud->addColumn([
                 'name'  => 'guard_name',

--- a/src/app/Http/Controllers/UserCrudController.php
+++ b/src/app/Http/Controllers/UserCrudController.php
@@ -16,8 +16,7 @@ class UserCrudController extends CrudController
 
     public function setup()
     {
-        $this->crud->setModel(config('backpack.permissionmanager.models.user'));
-        $this->crud->setEntityNameStrings(trans('backpack::permissionmanager.user'), trans('backpack::permissionmanager.users'));
+        $this->crud->setModel(config('backpack.permissionmanager.models.user'));        $this->crud->setEntityNameStrings(trans('backpack::permissionmanager.user'), trans('backpack::permissionmanager.users'));
         $this->crud->setRoute(backpack_url('user'));
     }
 
@@ -61,10 +60,10 @@ class UserCrudController extends CrudController
             ],
             config('permission.models.role')::all()->pluck('name', 'id')->toArray(),
             function ($value) { // if the filter is active
-            $this->crud->addClause('whereHas', 'roles', function ($query) use ($value) {
-                $query->where('role_id', '=', $value);
-            });
-        }
+                $this->crud->addClause('whereHas', 'roles', function ($query) use ($value) {
+                    $query->where('role_id', '=', $value);
+                });
+            }
         );
 
         // Extra Permission Filter
@@ -76,10 +75,10 @@ class UserCrudController extends CrudController
             ],
             config('permission.models.permission')::all()->pluck('name', 'id')->toArray(),
             function ($value) { // if the filter is active
-            $this->crud->addClause('whereHas', 'permissions', function ($query) use ($value) {
-                $query->where('permission_id', '=', $value);
-            });
-        }
+                $this->crud->addClause('whereHas', 'permissions', function ($query) use ($value) {
+                    $query->where('permission_id', '=', $value);
+                });
+            }
         );
     }
 
@@ -102,8 +101,8 @@ class UserCrudController extends CrudController
      */
     public function store()
     {
-        $this->crud->request = $this->crud->validateRequest();
-        $this->crud->request = $this->handlePasswordInput($this->crud->request);
+        $this->crud->setRequest($this->crud->validateRequest());
+        $this->crud->setRequest($this->handlePasswordInput($this->crud->getRequest()));
         $this->crud->unsetValidation(); // validation has already been run
 
         return $this->traitStore();
@@ -116,8 +115,8 @@ class UserCrudController extends CrudController
      */
     public function update()
     {
-        $this->crud->request = $this->crud->validateRequest();
-        $this->crud->request = $this->handlePasswordInput($this->crud->request);
+        $this->crud->setRequest($this->crud->validateRequest());
+        $this->crud->setRequest($this->handlePasswordInput($this->crud->getRequest()));
         $this->crud->unsetValidation(); // validation has already been run
 
         return $this->traitUpdate();

--- a/src/config/backpack/permissionmanager.php
+++ b/src/config/backpack/permissionmanager.php
@@ -12,7 +12,7 @@ return [
     */
 
     'models' => [
-        'user'       => App\Models\BackpackUser::class,
+        'user'       => App\User::class,
         'permission' => Backpack\PermissionManager\app\Models\Permission::class,
         'role'       => Backpack\PermissionManager\app\Models\Role::class,
     ],

--- a/src/database/migrations/2020_03_31_114745_remove_backpackuser_model.php
+++ b/src/database/migrations/2020_03_31_114745_remove_backpackuser_model.php
@@ -1,8 +1,6 @@
 <?php
 
 use Illuminate\Database\Migrations\Migration;
-use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 
@@ -31,7 +29,7 @@ class RemoveBackpackuserModel extends Migration
         // if you've ended up with duplicate entries (both for App\User and App\Models\BackpackUser)
         // we can just delete them
         $userEntries = DB::table($table_name)
-            ->where("model_type", "App\User")
+            ->where('model_type', "App\User")
             ->get();
 
         foreach ($userEntries as $entry) {
@@ -44,9 +42,9 @@ class RemoveBackpackuserModel extends Migration
 
         // for the rest of them, we can just replace the BackpackUser model with User
         DB::table($table_name)
-            ->where("model_type", "App\Models\BackpackUser")
+            ->where('model_type', "App\Models\BackpackUser")
             ->update([
-                "model_type" => "App\User"
+                'model_type' => "App\User",
             ]);
     }
 }

--- a/src/database/migrations/2020_03_31_114745_remove_backpackuser_model.php
+++ b/src/database/migrations/2020_03_31_114745_remove_backpackuser_model.php
@@ -1,0 +1,52 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+class RemoveBackpackuserModel extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // establish the table names
+        $model_has_roles = config('permission.table_names.model_has_roles');
+        $model_has_permissions = config('permission.table_names.model_has_permissions');
+
+        // replace the BackpackUser model with User
+        $this->replaceModels($model_has_roles);
+        $this->replaceModels($model_has_permissions);
+    }
+
+    public function replaceModels($table_name)
+    {
+        Log::info('Replacing BackpackUser model in '.$table_name);
+
+        // if you've ended up with duplicate entries (both for App\User and App\Models\BackpackUser)
+        // we can just delete them
+        $userEntries = DB::table($table_name)
+            ->where("model_type", "App\User")
+            ->get();
+
+        foreach ($userEntries as $entry) {
+            DB::table($table_name)
+                ->where('role_id', $entry->role_id)
+                ->where('model_type', 'App\Models\BackpackUser')
+                ->where('model_id', $entry->model_id)
+                ->delete();
+        }
+
+        // for the rest of them, we can just replace the BackpackUser model with User
+        DB::table($table_name)
+            ->where("model_type", "App\Models\BackpackUser")
+            ->update([
+                "model_type" => "App\User"
+            ]);
+    }
+}


### PR DESCRIPTION
- Fixes #225 
- Adds a new ```relationship_count``` column to to RoleCrudController, which has a link to the UserCrudController, filtering to only see the users that have that role. This column also function as a sort of statistic - to easily understand how many admins/editors/etc you have:

![2020-03-31 11 44 32](https://user-images.githubusercontent.com/1032474/78005992-0ca06f80-7345-11ea-91aa-ba0d6bba04a0.gif)

- Makes the UserCrudController use the ```App/User``` model by default, instead of ```App/Models/BackpackUser```, because in https://github.com/Laravel-Backpack/CRUD/pull/2619 we plan to remove the BackpackUser model entirely; this fixes a problem where you add a new User with permissions - but because it's morphable, those permissions are actually stored on the BackpackUser model, not User;


HUGE BREAKING CHANGE. To upgrade:
- you need Backpack 4.1;
- you need to replace ```App\Models\BackpackUser``` with ```App\User``` in all entries in your ```model_has_roles``` and ```model_has_permissions``` tables;

For the 99% use case, where you haven't modified the table names, or anything like that, we've provided a migration that will convert everything in ```model_has_roles``` and ```model_has_permissions``` tables from BackpackUser to User:

```php
// VERY IMPORTANT: back up your database; there's no way back from this
php artisan vendor:publish --provider="Backpack\PermissionManager\PermissionManagerServiceProvider" --tag="migrations"
php artisan migrate
```