### PR TITLE
check if tables exists before performing changes.

### DIFF
--- a/src/database/migrations/2020_03_31_114745_remove_backpackuser_model.php
+++ b/src/database/migrations/2020_03_31_114745_remove_backpackuser_model.php
@@ -18,8 +18,12 @@ class RemoveBackpackuserModel extends Migration
         $model_has_permissions = config('permission.table_names.model_has_permissions');
 
         // replace the BackpackUser model with User
-        $this->replaceModels($model_has_roles);
-        $this->replaceModels($model_has_permissions);
+        if (\Illuminate\Support\Facades\Schema::hasTable($model_has_roles)) {
+            $this->replaceModels($model_has_roles);
+        }
+        if (\Illuminate\Support\Facades\Schema::hasTable($model_has_permissions)) {
+            $this->replaceModels($model_has_permissions);
+        }
     }
 
     public function replaceModels($table_name)


### PR DESCRIPTION
checking if model_has_roles and model_has_permissions tables exists before replacing models,
i guess the issue i faced was due to dating the migration, the RemoveBackpackuserModel migration created before permissions tables. as you can see in the picture, i guess changing the date will solve the issue too.

here's the issue:
![Capture d’écran 2020-04-26 à 23 56 59](https://user-images.githubusercontent.com/1247248/80320939-b6c2c880-8819-11ea-917c-e4dbc7709d90.png)

and here's the RemoveBackpackuserModel migration in my project created before my permissions migrations model.
![Capture d’écran 2020-04-26 à 23 55 57](https://user-images.githubusercontent.com/1247248/80320901-7a8f6800-8819-11ea-9cc1-c8bc7f7fad44.png)
