### PR TITLE
Use authentication column

### DIFF
--- a/src/app/Http/Controllers/UserCrudController.php
+++ b/src/app/Http/Controllers/UserCrudController.php
@@ -52,10 +52,10 @@ class UserCrudController extends CrudController
             ],
         ]);
 
-        if(config('backpack.base.authentication_column') !== 'email') {
+        if (config('backpack.base.authentication_column') !== 'email') {
             $this->crud->addColumn([
-                'name' => config('backpack.base.authentication_column'),
-                'type' => 'text',
+                'name'  => config('backpack.base.authentication_column'),
+                'type'  => 'text',
                 'label' => config('backpack.base.authentication_column_name'),
             ])->afterColumn('name');
         }
@@ -205,10 +205,10 @@ class UserCrudController extends CrudController
             ],
         ]);
 
-        if(config('backpack.base.authentication_column') !== 'email') {
+        if (config('backpack.base.authentication_column') !== 'email') {
             $this->crud->addField([
-                'name' => config('backpack.base.authentication_column'),
-                'type' => 'text',
+                'name'  => config('backpack.base.authentication_column'),
+                'type'  => 'text',
                 'label' => config('backpack.base.authentication_column_name'),
             ])->afterField('name');
         }

--- a/src/app/Http/Controllers/UserCrudController.php
+++ b/src/app/Http/Controllers/UserCrudController.php
@@ -52,6 +52,14 @@ class UserCrudController extends CrudController
             ],
         ]);
 
+        if(config('backpack.base.authentication_column') !== 'email') {
+            $this->crud->addColumn([
+                'name' => config('backpack.base.authentication_column'),
+                'type' => 'text',
+                'label' => config('backpack.base.authentication_column_name'),
+            ])->afterColumn('name');
+        }
+
         // Role Filter
         $this->crud->addFilter(
             [
@@ -196,5 +204,13 @@ class UserCrudController extends CrudController
                 ],
             ],
         ]);
+
+        if(config('backpack.base.authentication_column') !== 'email') {
+            $this->crud->addField([
+                'name' => config('backpack.base.authentication_column'),
+                'type' => 'text',
+                'label' => config('backpack.base.authentication_column_name'),
+            ])->afterField('name');
+        }
     }
 }

--- a/src/app/Http/Requests/UserStoreCrudRequest.php
+++ b/src/app/Http/Requests/UserStoreCrudRequest.php
@@ -24,10 +24,16 @@ class UserStoreCrudRequest extends FormRequest
      */
     public function rules()
     {
-        return [
+        $returnable = [
             'email'    => 'required|unique:'.config('permission.table_names.users', 'users').',email',
             'name'     => 'required',
             'password' => 'required|confirmed',
         ];
+
+        if(config('backpack.base.authentication_column') !== 'email') {
+            $returnable[config('backpack.base.authentication_column')] = 'required|unique:'.config('permission.table_names.users', 'users').','.config('backpack.base.authentication_column');
+        }
+
+        return $returnable;
     }
 }

--- a/src/app/Http/Requests/UserStoreCrudRequest.php
+++ b/src/app/Http/Requests/UserStoreCrudRequest.php
@@ -30,7 +30,7 @@ class UserStoreCrudRequest extends FormRequest
             'password' => 'required|confirmed',
         ];
 
-        if(config('backpack.base.authentication_column') !== 'email') {
+        if (config('backpack.base.authentication_column') !== 'email') {
             $returnable[config('backpack.base.authentication_column')] = 'required|unique:'.config('permission.table_names.users', 'users').','.config('backpack.base.authentication_column');
         }
 

--- a/src/app/Http/Requests/UserUpdateCrudRequest.php
+++ b/src/app/Http/Requests/UserUpdateCrudRequest.php
@@ -40,7 +40,7 @@ class UserUpdateCrudRequest extends FormRequest
             'password' => 'confirmed',
         ];
 
-        if(config('backpack.base.authentication_column') !== 'email') {
+        if (config('backpack.base.authentication_column') !== 'email') {
             $returnable[config('backpack.base.authentication_column')] = 'required|unique:'.config('permission.table_names.users', 'users').','.config('backpack.base.authentication_column');
         }
 

--- a/src/app/Http/Requests/UserUpdateCrudRequest.php
+++ b/src/app/Http/Requests/UserUpdateCrudRequest.php
@@ -34,10 +34,16 @@ class UserUpdateCrudRequest extends FormRequest
             abort(400, 'Could not find that entry in the database.');
         }
 
-        return [
+        $returnable = [
             'email'    => 'required|unique:'.config('permission.table_names.users', 'users').',email,'.$userId,
             'name'     => 'required',
             'password' => 'confirmed',
         ];
+
+        if(config('backpack.base.authentication_column') !== 'email') {
+            $returnable[config('backpack.base.authentication_column')] = 'required|unique:'.config('permission.table_names.users', 'users').','.config('backpack.base.authentication_column');
+        }
+
+        return $returnable;
     }
 }


### PR DESCRIPTION
This is for issue #213  creates a new field and column allowing for custom authentication column. Also adds that necessary requirement for it.

Note: Email is still a required field. I can't think of any apps that don't really use an email for something.

![Screen Shot 2020-05-16 at 11 39 46 PM](https://user-images.githubusercontent.com/487798/82137711-521edc00-97cf-11ea-82a7-35d424188e1f.png)

![Screen Shot 2020-05-16 at 11 39 59 PM](https://user-images.githubusercontent.com/487798/82137709-50edaf00-97cf-11ea-98a5-c4954767fa18.png)

- Non-Breaking Change
- Tested it on a live product and fresh install.