### PR TITLE
Use Base User Model By Default

### DIFF
--- a/src/config/backpack/permissionmanager.php
+++ b/src/config/backpack/permissionmanager.php
@@ -12,7 +12,7 @@ return [
     */
 
     'models' => [
-        'user'       => App\User::class,
+        'user'       => config('backpack.base.user_model_fqn', \App\User::class),
         'permission' => Backpack\PermissionManager\app\Models\Permission::class,
         'role'       => Backpack\PermissionManager\app\Models\Role::class,
     ],


### PR DESCRIPTION
Seem's more friendly to default to the backpack/base config user model, then user only has to change once if using different model other then 'App\User'