### PR TITLE
Users CRUD - use addColumns instead of setColumns

### DIFF
--- a/src/app/Http/Controllers/UserCrudController.php
+++ b/src/app/Http/Controllers/UserCrudController.php
@@ -23,7 +23,7 @@ class UserCrudController extends CrudController
 
     public function setupListOperation()
     {
-        $this->crud->setColumns([
+        $this->crud->addColumns([
             [
                 'name'  => 'name',
                 'label' => trans('backpack::permissionmanager.name'),


### PR DESCRIPTION
That way, other operations can add/remove columns in their setupXxxDefaults() methods.