### PR TITLE
replace relationship_count column in Roles CRUD with a text one

### DIFF
--- a/src/app/Http/Controllers/RoleCrudController.php
+++ b/src/app/Http/Controllers/RoleCrudController.php
@@ -46,7 +46,7 @@ class RoleCrudController extends CrudController
             'label' => trans('backpack::permissionmanager.name'),
             'type'  => 'text',
         ]);
-        
+
         /**
          * Show a column with the number of users that have that particular role.
          *
@@ -54,7 +54,7 @@ class RoleCrudController extends CrudController
          * of users for a role, we did not use the `relationship_count` column,
          * but instead opted to append a fake `user_count` column to
          * the result, using Laravel's `withCount()` method.
-         * That way, no users are loaded. 
+         * That way, no users are loaded.
          */
         $this->crud->query->withCount('users');
         $this->crud->addColumn([


### PR DESCRIPTION
Fixes https://github.com/Laravel-Backpack/CRUD/issues/3227 . 


**The Problem**

Because we were using the `relationship_count` column, for every Role all Users were loaded onto the page, in order to count them. With a big Users table this quickly got out of hand, causing performance issues (15 sec load time for example). 

**The Solution**

This PR replaces the `relationship_count` column with a `text` column, and calculates the `users_count` ahead of time, using a method Laravel provides that is A LOT faster and does not load the Users at all.

