### PR TITLE
Fix route evaluation on user update request

### DIFF
--- a/src/app/Http/Requests/UserUpdateCrudRequest.php
+++ b/src/app/Http/Requests/UserUpdateCrudRequest.php
@@ -24,15 +24,9 @@ class UserUpdateCrudRequest extends FormRequest
      */
     public function rules()
     {
-        $userModel = config('backpack.permissionmanager.models.user');
-        $userModel = new $userModel();
-        $routeSegmentWithId = empty(config('backpack.base.route_prefix')) ? '2' : '3';
-
-        $userId = $this->get('id') ?? \Request::instance()->segment($routeSegmentWithId);
-
-        if (!$userModel->find($userId)) {
-            abort(400, 'Could not find that entry in the database.');
-        }
+        $userId = $this->get('id') ?? \Arr::last(request()->segments(), function ($value) {
+            return is_numeric($value);
+        });
 
         return [
             'email'    => 'required|unique:'.config('permission.table_names.users', 'users').',email,'.$userId,

--- a/src/app/Http/Requests/UserUpdateCrudRequest.php
+++ b/src/app/Http/Requests/UserUpdateCrudRequest.php
@@ -24,12 +24,10 @@ class UserUpdateCrudRequest extends FormRequest
      */
     public function rules()
     {
-        $userId = $this->get('id') ?? \Arr::last(request()->segments(), function ($value) {
-            return is_numeric($value);
-        });
+        $id = $this->get('id') ?? request()->route('id');
 
         return [
-            'email'    => 'required|unique:'.config('permission.table_names.users', 'users').',email,'.$userId,
+            'email'    => 'required|unique:'.config('permission.table_names.users', 'users').',email,'.$id,
             'name'     => 'required',
             'password' => 'confirmed',
         ];


### PR DESCRIPTION
This PR fixes #258 
As @EvgeniySyo reported, the validation was not considering different configurations for `route_prefix`.

I used `Arr::last` to get the last numeric value on the route since its values will be either `.../admin/user/123` or `.../admin/user/123/edit`.
I thought about using regex, it would be more guaranteed to match the ID, but this is more readable and I think it covers all the use cases.

I also removed a validation where this specific request was checking if the user existed. I don't know why this was being done just here, probably it was some old code that was never reviewed, because Backpack by default checks if the ID exists and throws an erro if it doesn't. And that's exactly what this piece of code was doing.