### PR TITLE
Avoid publish all files

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,20 +34,24 @@ This package is just a user interface for [spatie/laravel-permission](https://gi
 composer require backpack/permissionmanager
 ```
 
-2) Finish all installation steps for [spatie/laravel-permission](https://github.com/spatie/laravel-permission#installation), which as been pulled as a dependency. Run its migrations. Publish its config files. Most likely it's:
+2) Finish all installation steps for [`spatie/laravel-permission`](https://spatie.be/docs/laravel-permission/v3/installation-laravel), which as been pulled as a dependency. Publish its migrations and config files. Most likely it's:
 ```bash
-php artisan vendor:publish --provider="Spatie\Permission\PermissionServiceProvider" --tag="migrations"
-php artisan migrate
-php artisan vendor:publish --provider="Spatie\Permission\PermissionServiceProvider" --tag="config"
+php artisan vendor:publish --provider="Spatie\Permission\PermissionServiceProvider"
 // then First, add the Spatie\Permission\Traits\HasRoles trait to your User model(s)
 ```
 
-3) Publish the config file & run the migrations
+3) Publish `backpack\permissionmanager` config file:
 ```bash
-php artisan vendor:publish --provider="Backpack\PermissionManager\PermissionManagerServiceProvider"
+php artisan vendor:publish --provider="Backpack\PermissionManager\PermissionManagerServiceProvider" --tag="config"
+```
+> Note: _We recommend you to publish only the config file, but you may also publish lang and routes._
+
+4) Run the migrations:
+```bash
+php artisan migrate
 ```
 
-4) The package assumes it's ok to use ```App\Models\BackpackUser``` to administer Users. Use a different one if you'd like by changing the user model in the ```config/backpack/permissionmanager.php``` file. Any model you're using, make sure it's using the ```CrudTrait``` and ```HasRoles``` traits:
+5) The package assumes it's ok to use ```App\Models\BackpackUser``` to administer Users. Use a different one if you'd like by changing the user model in the ```config/backpack/permissionmanager.php``` file. Any model you're using, make sure it's using the ```CrudTrait``` and ```HasRoles``` traits:
 ```php
 <?php namespace App;
 
@@ -65,7 +69,7 @@ class User extends Authenticatable
      */
 ```
 
-5) [Optional] Add a menu item for it in ```resources/views/vendor/backpack/base/inc/sidebar_content.blade.php``` or ```menu.blade.php```:
+6) [Optional] Add a menu item for it in ```resources/views/vendor/backpack/base/inc/sidebar_content.blade.php``` or ```menu.blade.php```:
 
 ```html
 <!-- Users, Roles, Permissions -->
@@ -79,9 +83,9 @@ class User extends Authenticatable
 </li>
 ```
 
-6) [Optional] If you want to use the ```@can``` handler inside Backpack routes, you can:
+7) [Optional] If you want to use the ```@can``` handler inside Backpack routes, you can:
 
-(6.A.) Change Backpack to use the default ```web``` guard instead of its own guard. Inside ```config/backpack/base.php``` change:
+(7.A.) Change Backpack to use the default ```web``` guard instead of its own guard. Inside ```config/backpack/base.php``` change:
 ```diff
     // The guard that protects the Backpack admin panel.
     // If null, the config.auth.defaults.guard value will be used.
@@ -93,7 +97,7 @@ Note:
 
 OR
 
-(6.B.) Add a middleware to all your Backpack routes by adding this to your ```config/backpack/base.php``` file:
+(7.B.) Add a middleware to all your Backpack routes by adding this to your ```config/backpack/base.php``` file:
 ```diff
     // The classes for the middleware to check if the visitor is an admin
     // Can be a single class or an array of clases
@@ -112,7 +116,7 @@ Please note:
 - when you add new roles and permissions, the guard that gets saved in the database will be "backpack";
 
 
-7) [Optional] Disallow create/update on your roles or permissions after you define them, using the config file in **config/backpack/permissionmanager.php**. Please note permissions and roles are referenced in code using their name. If you let your admins edit these strings and they do, your permission and role checks will stop working.
+8) [Optional] Disallow create/update on your roles or permissions after you define them, using the config file in **config/backpack/permissionmanager.php**. Please note permissions and roles are referenced in code using their name. If you let your admins edit these strings and they do, your permission and role checks will stop working.
 
 
 ## Customize UserCrudController

--- a/src/PermissionManagerServiceProvider.php
+++ b/src/PermissionManagerServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace Backpack\PermissionManager;
 
-use Config;
 use Illuminate\Routing\Router;
 use Illuminate\Support\ServiceProvider;
 use Spatie\Permission\PermissionServiceProvider;
@@ -45,8 +44,8 @@ class PermissionManagerServiceProvider extends ServiceProvider
         // publish translation files
         $this->publishes([__DIR__.'/resources/lang' => resource_path('lang/vendor/backpack')], 'lang');
 
-        // publish migration from Backpack 4.0 to Backpack 4.1
-        $this->publishes([__DIR__.'/database/migrations' => database_path('migrations')], 'migrations');
+        // load migration from Backpack 4.0 to Backpack 4.1
+        $this->loadMigrationsFrom(__DIR__.'/database/migrations');
     }
 
     /**


### PR DESCRIPTION
Related with #267

Ok, I've been "investigating" 😅
Now we publish;
- migrations
- configs
- translations
- (and routes with #267)

**Config** isn't needed, but I think we should publish. 🤷‍♂️ Let me know what you think.
**Translations** aren't needed, laravel loads them.
**Migrations** aren't need, Laravel can load them, but we need to change the code from `publishMigrations` to `loadMigrationsFrom`.

I did that on this PR, this makes the migrations mandatory, developers can't opt out.
I think it's ok in this case, but let me know if you don't think that way.