### PR TITLE
Support for spatie/laravel-permission v4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "spatie/laravel-permission": "^3.0",
+        "spatie/laravel-permission": "^4.0|^3.0",
         "backpack/crud": "^4.1.0"
     },
     "require-dev": {


### PR DESCRIPTION
Fix for #269.

Apparently there weren't major breaking changes.
The changelog for this versions is here;
https://github.com/spatie/laravel-permission/blob/master/CHANGELOG.md

The major BC by this version is something that backpack already did;
- PHP >7.2.5
- Laravel >6.

I tested on demo and everything seems to be working.
