### PR TITLE
Revert loading migrations instead of publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,11 @@ php artisan vendor:publish --provider="Spatie\Permission\PermissionServiceProvid
 // then, add the Spatie\Permission\Traits\HasRoles trait to your User model(s)
 ```
 
-3) Publish `backpack\permissionmanager` config file:
+3) Publish `backpack\permissionmanager` config file & the migrations:
 ```bash
-php artisan vendor:publish --provider="Backpack\PermissionManager\PermissionManagerServiceProvider" --tag="config"
+php artisan vendor:publish --provider="Backpack\PermissionManager\PermissionManagerServiceProvider" --tag="config" --tag="migrations"
 ```
-> Note: _We recommend you to publish only the config file, but you may also publish lang and routes._
+> Note: _We recommend you to publish only the config file and migrations, but you may also publish lang and routes._
 
 4) Run the migrations:
 ```bash

--- a/src/PermissionManagerServiceProvider.php
+++ b/src/PermissionManagerServiceProvider.php
@@ -47,8 +47,8 @@ class PermissionManagerServiceProvider extends ServiceProvider
         // publish route file
         $this->publishes([__DIR__.$this->routeFilePath => base_path($this->routeFilePath)], 'routes');
 
-        // load migration from Backpack 4.0 to Backpack 4.1
-        $this->loadMigrationsFrom(__DIR__.'/database/migrations');
+        // publish migration from Backpack 4.0 to Backpack 4.1
+        $this->publishes([__DIR__.'/database/migrations' => database_path('migrations')], 'migrations');
     }
 
     /**


### PR DESCRIPTION
Fix to @ian-patel issue on https://github.com/Laravel-Backpack/PermissionManager/commit/e3b9756afc2b4eb0ca11b4770b0c20356cc50669#r50448573

This reverts the loading of the migrations, instead of publishing it.

@tabacitu I'm not sure if we should ever change this, probably in an upcoming version we can even remove this migration since it's only needed when migrating from 4.0 to 4.1.