### PR TITLE
Translate the 'users' suffix on the Users Column on RoleCrudController.php

### DIFF
--- a/src/app/Http/Controllers/RoleCrudController.php
+++ b/src/app/Http/Controllers/RoleCrudController.php
@@ -66,7 +66,7 @@ class RoleCrudController extends CrudController
                     return backpack_url('user?role='.$entry->getKey());
                 },
             ],
-            'suffix'    => ' users',
+            'suffix'    => ' ' . strtolower(trans('backpack::permissionmanager.users')),
         ]);
 
         /**


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Not sure if this was intentionally left out. But the suffix was hardcoded as ' users'.

### AFTER - What is happening after this PR?

Suffix translated.


## HOW

### How did you achieve that, in technical terms?

```
'suffix'    => ' ' . strtolower(trans('backpack::permissionmanager.users')),
```


### Is it a breaking change or non-breaking change?

Don't think it is.


### How can we test the before & after?

It's a super minor PR
