### PR TITLE
[untested] restored Backpack `^v4.1` compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,10 +34,10 @@
     "prefer-stable": true,
     "require": {
         "spatie/laravel-permission": "^5.0|^4.0|^3.0",
-        "backpack/crud": "^5.0"
+        "backpack/crud": "^5.0|^4.1"
     },
     "require-dev": {
-        "phpunit/phpunit" : "^9.0||^7.0",
+        "phpunit/phpunit": "^9.0||^7.0",
         "scrutinizer/ocular": "~1.1"
     },
     "autoload": {

--- a/src/app/Http/Controllers/UserCrudController.php
+++ b/src/app/Http/Controllers/UserCrudController.php
@@ -52,7 +52,7 @@ class UserCrudController extends CrudController
             ],
         ]);
 
-        if (backpack_pro()) {
+        if (backpack_pro() || !function_exists('backpack_pro')) {
             // Role Filter
             $this->crud->addFilter(
                 [


### PR DESCRIPTION
## WHY
`6.0.12` introduced a breaking change where it dropped support for Backpack v4

## HOW

### How did you achieve that, in technical terms?
Since ```backpack_pro()``` only exists in v5+, this adds a additional clause to include the previously available functions. 



### Is it a breaking change or non-breaking change?

Non-breaking


### How can we test the before & after?

If it builds with v4, that'll do it.