### PR TITLE
Corrects the labels for roles

### DIFF
--- a/src/app/Http/Controllers/RoleCrudController.php
+++ b/src/app/Http/Controllers/RoleCrudController.php
@@ -85,7 +85,7 @@ class RoleCrudController extends CrudController
          */
         $this->crud->addColumn([
             // n-n relationship (with pivot table)
-            'label'     => ucfirst(trans('backpack::permissionmanager.permission_plural')),
+            'label'     => mb_ucfirst(trans('backpack::permissionmanager.permission_plural')),
             'type'      => 'select_multiple',
             'name'      => 'permissions', // the method that defines the relationship in your Model
             'entity'    => 'permissions', // the method that defines the relationship in your Model
@@ -131,7 +131,7 @@ class RoleCrudController extends CrudController
         }
 
         $this->crud->addField([
-            'label'     => ucfirst(trans('backpack::permissionmanager.permission_plural')),
+            'label'     => mb_ucfirst(trans('backpack::permissionmanager.permission_plural')),
             'type'      => 'checklist',
             'name'      => 'permissions',
             'entity'    => 'permissions',


### PR DESCRIPTION
This fix is replacing ucfirst() to mb_usfirst() for the supporting of multibyte strings