### PR TITLE
Update permissionmanager.php

### DIFF
--- a/src/resources/lang/it/permissionmanager.php
+++ b/src/resources/lang/it/permissionmanager.php
@@ -8,6 +8,7 @@ return [
     |
     | The following language lines are used for Laravel Backpack - Permission Manager
     | Author: Roberto Butti ( https://github.com/roberto-butti )
+    |         Mirko Tebaldi ( https://github.com/realtebo )
     | Language: Italian
     |
     */
@@ -26,5 +27,5 @@ return [
     'user_role_permission'  => 'Utenti Ruoli Permessi',
     'user'                  => 'Utente',
     'users'                 => 'Utenti',
-
+    'guard_type'            => 'Tipo Guard',
 ];


### PR DESCRIPTION
Added missing italian translation

## WHY

There was a missing translation

### BEFORE - What was wrong? What was happening before this PR?

No error, but there was a missing translation

### AFTER - What is happening after this PR?

No more missing translation

## HOW

### How did you achieve that, in technical terms?

Added a missing key in lang file

### Is it a breaking change or non-breaking change?

No braking change

### How can we test the before & after?

You could customize crud to add the 'guard_type' column and setting locale of app to italian.