### PR TITLE
enable/disable password field on User model using config

### DIFF
--- a/src/app/Http/Controllers/UserCrudController.php
+++ b/src/app/Http/Controllers/UserCrudController.php
@@ -16,7 +16,7 @@ class UserCrudController extends CrudController
 
     public function setup()
     {
-        $this->crud->setModel(config('backpack.permissionmanager.models.user'));
+        $this->crud->setModel(config('backpack.permissionmanager.models.user.model'));
         $this->crud->setEntityNameStrings(trans('backpack::permissionmanager.user'), trans('backpack::permissionmanager.users'));
         $this->crud->setRoute(backpack_url('user'));
     }
@@ -136,7 +136,7 @@ class UserCrudController extends CrudController
         $request->request->remove('permissions_show');
 
         // Encrypt password if specified.
-        if ($request->input('password')) {
+        if (config('backpack.permissionmanager.models.user.is_password_enabled', true) && $request->input('password')) {
             $request->request->set('password', Hash::make($request->input('password')));
         } else {
             $request->request->remove('password');
@@ -147,7 +147,7 @@ class UserCrudController extends CrudController
 
     protected function addUserFields()
     {
-        $this->crud->addFields([
+        $fields = [
             [
                 'name'  => 'name',
                 'label' => trans('backpack::permissionmanager.name'),
@@ -158,45 +158,52 @@ class UserCrudController extends CrudController
                 'label' => trans('backpack::permissionmanager.email'),
                 'type'  => 'email',
             ],
-            [
+        ];
+
+        if (config('backpack.permissionmanager.models.user.is_password_enabled', true)) {
+            $fields[] = [
                 'name'  => 'password',
                 'label' => trans('backpack::permissionmanager.password'),
                 'type'  => 'password',
-            ],
-            [
+            ];
+
+            $fields[] = [
                 'name'  => 'password_confirmation',
                 'label' => trans('backpack::permissionmanager.password_confirmation'),
                 'type'  => 'password',
-            ],
-            [
-                // two interconnected entities
-                'label'             => trans('backpack::permissionmanager.user_role_permission'),
-                'field_unique_name' => 'user_role_permission',
-                'type'              => 'checklist_dependency',
-                'name'              => ['roles', 'permissions'],
-                'subfields'         => [
-                    'primary' => [
-                        'label'            => trans('backpack::permissionmanager.roles'),
-                        'name'             => 'roles', // the method that defines the relationship in your Model
-                        'entity'           => 'roles', // the method that defines the relationship in your Model
-                        'entity_secondary' => 'permissions', // the method that defines the relationship in your Model
-                        'attribute'        => 'name', // foreign key attribute that is shown to user
-                        'model'            => config('permission.models.role'), // foreign key model
-                        'pivot'            => true, // on create&update, do you need to add/delete pivot table entries?]
-                        'number_columns'   => 3, //can be 1,2,3,4,6
-                    ],
-                    'secondary' => [
-                        'label'          => mb_ucfirst(trans('backpack::permissionmanager.permission_plural')),
-                        'name'           => 'permissions', // the method that defines the relationship in your Model
-                        'entity'         => 'permissions', // the method that defines the relationship in your Model
-                        'entity_primary' => 'roles', // the method that defines the relationship in your Model
-                        'attribute'      => 'name', // foreign key attribute that is shown to user
-                        'model'          => config('permission.models.permission'), // foreign key model
-                        'pivot'          => true, // on create&update, do you need to add/delete pivot table entries?]
-                        'number_columns' => 3, //can be 1,2,3,4,6
-                    ],
+            ];
+        }
+
+        $fields[] = [
+            // two interconnected entities
+            'label'             => trans('backpack::permissionmanager.user_role_permission'),
+            'field_unique_name' => 'user_role_permission',
+            'type'              => 'checklist_dependency',
+            'name'              => ['roles', 'permissions'],
+            'subfields'         => [
+                'primary' => [
+                    'label'            => trans('backpack::permissionmanager.roles'),
+                    'name'             => 'roles', // the method that defines the relationship in your Model
+                    'entity'           => 'roles', // the method that defines the relationship in your Model
+                    'entity_secondary' => 'permissions', // the method that defines the relationship in your Model
+                    'attribute'        => 'name', // foreign key attribute that is shown to user
+                    'model'            => config('permission.models.role'), // foreign key model
+                    'pivot'            => true, // on create&update, do you need to add/delete pivot table entries?]
+                    'number_columns'   => 3, //can be 1,2,3,4,6
+                ],
+                'secondary' => [
+                    'label'          => mb_ucfirst(trans('backpack::permissionmanager.permission_plural')),
+                    'name'           => 'permissions', // the method that defines the relationship in your Model
+                    'entity'         => 'permissions', // the method that defines the relationship in your Model
+                    'entity_primary' => 'roles', // the method that defines the relationship in your Model
+                    'attribute'      => 'name', // foreign key attribute that is shown to user
+                    'model'          => config('permission.models.permission'), // foreign key model
+                    'pivot'          => true, // on create&update, do you need to add/delete pivot table entries?]
+                    'number_columns' => 3, //can be 1,2,3,4,6
                 ],
             ],
-        ]);
+        ];
+
+        $this->crud->addFields($fields);
     }
 }

--- a/src/app/Http/Requests/UserStoreCrudRequest.php
+++ b/src/app/Http/Requests/UserStoreCrudRequest.php
@@ -24,10 +24,15 @@ class UserStoreCrudRequest extends FormRequest
      */
     public function rules()
     {
-        return [
+        $rules = [
             'email'    => 'required|unique:'.config('permission.table_names.users', 'users').',email',
             'name'     => 'required',
-            'password' => 'required|confirmed',
         ];
+
+        if (config('backpack.permissionmanager.models.user.is_password_enabled', true)) {
+            $rules['password'] = 'required|confirmed';
+        }
+
+        return $rules;
     }
 }

--- a/src/app/Http/Requests/UserUpdateCrudRequest.php
+++ b/src/app/Http/Requests/UserUpdateCrudRequest.php
@@ -26,10 +26,15 @@ class UserUpdateCrudRequest extends FormRequest
     {
         $id = $this->get('id') ?? request()->route('id');
 
-        return [
+        $rules = [
             'email'    => 'required|unique:'.config('permission.table_names.users', 'users').',email,'.$id,
             'name'     => 'required',
-            'password' => 'confirmed',
         ];
+
+        if (config('backpack.permissionmanager.models.user.is_password_enabled', true)) {
+            $rules['password'] = 'confirmed';
+        }
+
+        return $rules;
     }
 }

--- a/src/config/backpack/permissionmanager.php
+++ b/src/config/backpack/permissionmanager.php
@@ -12,7 +12,10 @@ return [
     */
 
     'models' => [
-        'user'       => config('backpack.base.user_model_fqn', \App\Models\User::class),
+        'user'       => [
+            'model' => config('backpack.base.user_model_fqn', \App\Models\User::class),
+            'is_password_enabled' => true,
+        ],
         'permission' => Backpack\PermissionManager\app\Models\Permission::class,
         'role'       => Backpack\PermissionManager\app\Models\Role::class,
     ],


### PR DESCRIPTION
## WHY

Can disable password-related entries if the model doesn't have the `password` field.
Scenario: Users can log in using the organization's SSO.

### BEFORE - What was wrong? What was happening before this PR?

It was assumed that the model always has the password field.

### AFTER - What is happening after this PR?

Developers can decide if they want to show or disable password-related inputs, `true` by default.


## HOW

### How did you achieve that, in technical terms?

??



### Is it a breaking change or non-breaking change?

**No**


### How can we test the before & after?

:shrug: I just tested using my own fork!
