### PR TITLE
registers migration file with new name before publish

### DIFF
--- a/src/PermissionManagerServiceProvider.php
+++ b/src/PermissionManagerServiceProvider.php
@@ -48,7 +48,9 @@ class PermissionManagerServiceProvider extends ServiceProvider
         $this->publishes([__DIR__.$this->routeFilePath => base_path($this->routeFilePath)], 'routes');
 
         // publish migration from Backpack 4.0 to Backpack 4.1
-        $this->publishes([__DIR__.'/database/migrations' => database_path('migrations')], 'migrations');
+        $this->publishes([
+            __DIR__.'/database/migrations/2020_03_31_114745_remove_backpackuser_model.php' => database_path('migrations') . DIRECTORY_SEPARATOR . $this->generateNewMigrationFileName('2020_03_31_114745_remove_backpackuser_model.php')
+        ], 'migrations');
     }
 
     /**
@@ -79,5 +81,10 @@ class PermissionManagerServiceProvider extends ServiceProvider
     public function register()
     {
         $this->app->register(PermissionServiceProvider::class);
+    }
+
+    protected function generateNewMigrationFileName($oldName)
+    {
+        return preg_replace('/\d{4}_\d{2}_\d{2}_\d{6}/', date('Y_m_d_His'), $oldName);
     }
 }


### PR DESCRIPTION
## WHY

According to the documentation/readme file, the snippets are as follows.
```bash
# Publish and migrate spatie/laravel-permission
php artisan vendor:publish --provider="Spatie\Permission\PermissionServiceProvider" --tag="migrations"
# Generates a new migration file with date('Y_m_d_His')_migration_file_name.php
php artisan migrate

# Publish and migrate Laravel-Backpack/PermissionManager
php artisan vendor:publish --provider="Backpack\PermissionManager\PermissionManagerServiceProvider" --tag="config" --tag="migrations"
# Generate a new migration file with 2020_xyz_migration_file_name.php
php artisan migrate
```

Practically, there is nothing wrong. But as soon as you run `php artisan migrate:rollback` twice or `php artisan migrate:refresh`, theoretically there is nothing wrong, but the permission manager migration is supposed to be running after the laravel-permission.

Merging this PR will always run the migration after laravel-permission because the file will be generated with a higher timestamp and will get sorted after the laravel-permission migration.

### BEFORE - What was wrong? What was happening before this PR?

Explained in why

### AFTER - What is happening after this PR?

Explained in why


## HOW

### How did you achieve that, in technical terms?

??



### Is it a breaking change or non-breaking change?

??


### How can we test the before & after?

??
