### PR TITLE
Update README so Spatie Permission will publish migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ composer require backpack/permissionmanager
 
 2) Finish all installation steps for [spatie/laravel-permission](https://github.com/spatie/laravel-permission#installation), which as been pulled as a dependency. Run its migrations. Publish its config files. Most likely it's:
 ```shell
-php artisan vendor:publish --provider="Spatie\Permission\PermissionServiceProvider" --tag="migrations"
+php artisan vendor:publish --provider="Spatie\Permission\PermissionServiceProvider" --tag="permission-migrations"
 php artisan migrate
-php artisan vendor:publish --provider="Spatie\Permission\PermissionServiceProvider" --tag="config"
+php artisan vendor:publish --provider="Spatie\Permission\PermissionServiceProvider" --tag="permission-config"
 // then, add the Spatie\Permission\Traits\HasRoles trait to your User model(s)
 ```
 


### PR DESCRIPTION
## WHY

Doing the normal "php artisan vendor:publish --provider="Spatie\Permission\PermissionServiceProvider" --tag="migrations"" doesn't work as it's not called migrations in code but "permission-migrations".

### BEFORE - What was wrong? What was happening before this PR?

Doing the installation process you won't get the migration for the permission tables.

### AFTER - What is happening after this PR?

Using the right command you do get the migration and the config file.


## HOW

### How did you achieve that, in technical terms?

Change the migration and config tag to prefix with "permissions-"



### Is it a breaking change or non-breaking change?

Breaks nothing.


### How can we test the before & after?

Try to install then you'll see it doesn't publish the migration so the package won't work. Use the correct command then migrate now it does.
