### PR TITLE
remove spatie/laravel-permission v6 - it does not exist

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "spatie/laravel-permission": "^6.0||^5.0||^4.0||^3.0",
+        "spatie/laravel-permission": "^5.0||^4.0||^3.0",
         "backpack/crud": "^5.0"
     },
     "require-dev": {


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

We were supporting a version of spatie/laravel-permission that doesn't exist yet 🤯

### AFTER - What is happening after this PR?

We don't.

## TODO

- [ ] delete the 6.0.16 tag
- [ ] create a 6.0.16 tag