### PR TITLE
V6

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,12 +75,12 @@ class User extends Authenticatable
 ```html
 <!-- Users, Roles, Permissions -->
 <li class="nav-item nav-dropdown">
-    <a class="nav-link nav-dropdown-toggle" href="#"><i class="nav-icon la la-users"></i> Authentication</a>
-    <ul class="nav-dropdown-items">
-        <li class="nav-item"><a class="nav-link" href="{{ backpack_url('user') }}"><i class="nav-icon la la-user"></i> <span>Users</span></a></li>
-        <li class="nav-item"><a class="nav-link" href="{{ backpack_url('role') }}"><i class="nav-icon la la-id-badge"></i> <span>Roles</span></a></li>
-        <li class="nav-item"><a class="nav-link" href="{{ backpack_url('permission') }}"><i class="nav-icon la la-key"></i> <span>Permissions</span></a></li>
-    </ul>
+  <a class="nav-link nav-dropdown-toggle" href="#"><i class="nav-icon la la-group"></i> Authentication</a>
+  <ul class="nav-dropdown-items">
+    <li class="nav-item"><a class="nav-link" href="{{ backpack_url('user') }}"><i class="nav-icon la la-user"></i> <span>Users</span></a></li>
+    <li class="nav-item"><a class="nav-link" href="{{ backpack_url('role') }}"><i class="nav-icon la la-group"></i> <span>Roles</span></a></li>
+    <li class="nav-item"><a class="nav-link" href="{{ backpack_url('permission') }}"><i class="nav-icon la la-key"></i> <span>Permissions</span></a></li>
+  </ul>
 </li>
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     "prefer-stable": true,
     "require": {
         "spatie/laravel-permission": "^5.0||^4.0||^3.0",
-        "backpack/crud": "^5.0"
+        "backpack/crud": "^5.0|^6.0|v6.x-dev"
     },
     "require-dev": {
         "phpunit/phpunit" : "^9.0||^7.0",

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     "prefer-stable": true,
     "require": {
         "spatie/laravel-permission": "^5.0||^4.0||^3.0",
-        "backpack/crud": "^5.0|^6.0|v6.x-dev"
+        "backpack/crud": "^6.0"
     },
     "require-dev": {
         "phpunit/phpunit" : "^9.0||^7.0",

--- a/src/app/Http/Controllers/UserCrudController.php
+++ b/src/app/Http/Controllers/UserCrudController.php
@@ -173,7 +173,7 @@ class UserCrudController extends CrudController
                 'label'             => trans('backpack::permissionmanager.user_role_permission'),
                 'field_unique_name' => 'user_role_permission',
                 'type'              => 'checklist_dependency',
-                'name'              => ['roles', 'permissions'],
+                'name'              => 'roles,permissions',
                 'subfields'         => [
                     'primary' => [
                         'label'            => trans('backpack::permissionmanager.roles'),


### PR DESCRIPTION
Changes:
- ...

Breaking changes:
- checklist_dependency now uses `roles,permissions` as name instead of `['roles', 'permissions']`