### PR TITLE
fix php 8.2 deprecation warnings

### DIFF
--- a/src/app/Http/Controllers/PermissionCrudController.php
+++ b/src/app/Http/Controllers/PermissionCrudController.php
@@ -10,6 +10,9 @@ use Backpack\PermissionManager\app\Http\Requests\PermissionUpdateCrudRequest as 
 
 class PermissionCrudController extends CrudController
 {
+    protected $role_model;
+    protected $permission_model;
+
     use \Backpack\CRUD\app\Http\Controllers\Operations\ListOperation;
     use \Backpack\CRUD\app\Http\Controllers\Operations\CreateOperation;
     use \Backpack\CRUD\app\Http\Controllers\Operations\UpdateOperation;

--- a/src/app/Http/Controllers/PermissionCrudController.php
+++ b/src/app/Http/Controllers/PermissionCrudController.php
@@ -10,8 +10,8 @@ use Backpack\PermissionManager\app\Http\Requests\PermissionUpdateCrudRequest as 
 
 class PermissionCrudController extends CrudController
 {
-    protected $role_model;
-    protected $permission_model;
+    protected string $role_model;
+    protected string $permission_model;
 
     use \Backpack\CRUD\app\Http\Controllers\Operations\ListOperation;
     use \Backpack\CRUD\app\Http\Controllers\Operations\CreateOperation;

--- a/src/app/Http/Controllers/RoleCrudController.php
+++ b/src/app/Http/Controllers/RoleCrudController.php
@@ -10,6 +10,9 @@ use Backpack\PermissionManager\app\Http\Requests\RoleUpdateCrudRequest as Update
 
 class RoleCrudController extends CrudController
 {
+    protected $role_model;
+    protected $permission_model;
+
     use \Backpack\CRUD\app\Http\Controllers\Operations\ListOperation;
     use \Backpack\CRUD\app\Http\Controllers\Operations\CreateOperation;
     use \Backpack\CRUD\app\Http\Controllers\Operations\UpdateOperation;

--- a/src/app/Http/Controllers/RoleCrudController.php
+++ b/src/app/Http/Controllers/RoleCrudController.php
@@ -10,8 +10,8 @@ use Backpack\PermissionManager\app\Http\Requests\RoleUpdateCrudRequest as Update
 
 class RoleCrudController extends CrudController
 {
-    protected $role_model;
-    protected $permission_model;
+    protected string $role_model;
+    protected string $permission_model;
 
     use \Backpack\CRUD\app\Http\Controllers\Operations\ListOperation;
     use \Backpack\CRUD\app\Http\Controllers\Operations\CreateOperation;


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

`logs\deprecation-warnings.log`

```
[2023-10-19 07:43:25] staging.WARNING: Creation of dynamic property Backpack\PermissionManager\app\Http\Controllers\RoleCrudController::$role_model is deprecated in /vendor/backpack/permissionmanager/src/app/Http/Controllers/RoleCrudController.php on line 20
[2023-10-19 07:43:25] staging.WARNING: Creation of dynamic property Backpack\PermissionManager\app\Http\Controllers\RoleCrudController::$permission_model is deprecated in /vendor/backpack/permissionmanager/src/app/Http/Controllers/RoleCrudController.php on line 21


[2023-10-19 22:39:31] staging.WARNING: Creation of dynamic property Backpack\PermissionManager\app\Http\Controllers\PermissionCrudController::$role_model is deprecated in /vendor/backpack/permissionmanager/src/app/Http/Controllers/PermissionCrudController.php on line 20
[2023-10-19 22:39:31] staging.WARNING: Creation of dynamic property Backpack\PermissionManager\app\Http\Controllers\PermissionCrudController::$permission_model is deprecated in /vendor/backpack/permissionmanager/src/app/Http/Controllers/PermissionCrudController.php on line 21
```

PHP 8.2 Deprecated  https://php.watch/versions/8.2/dynamic-properties-deprecated

Similar Issue:   https://github.com/Laravel-Backpack/CRUD/pull/5082
