### PR TITLE
Fix reset cache

### DIFF
--- a/src/app/Http/Controllers/PermissionCrudController.php
+++ b/src/app/Http/Controllers/PermissionCrudController.php
@@ -5,6 +5,7 @@ namespace Backpack\PermissionManager\app\Http\Controllers;
 use Backpack\CRUD\app\Http\Controllers\CrudController;
 use Backpack\PermissionManager\app\Http\Requests\PermissionStoreCrudRequest as StoreRequest;
 use Backpack\PermissionManager\app\Http\Requests\PermissionUpdateCrudRequest as UpdateRequest;
+use Spatie\Permission\PermissionRegistrar;
 
 // VALIDATION
 
@@ -62,7 +63,7 @@ class PermissionCrudController extends CrudController
         $this->crud->setValidation(StoreRequest::class);
 
         //otherwise, changes won't have effect
-        \Cache::forget('spatie.permission.cache');
+        app()->make(PermissionRegistrar::class)->forgetCachedPermissions();
     }
 
     public function setupUpdateOperation()
@@ -71,7 +72,7 @@ class PermissionCrudController extends CrudController
         $this->crud->setValidation(UpdateRequest::class);
 
         //otherwise, changes won't have effect
-        \Cache::forget('spatie.permission.cache');
+        app()->make(PermissionRegistrar::class)->forgetCachedPermissions();
     }
 
     private function addFields()

--- a/src/app/Http/Controllers/RoleCrudController.php
+++ b/src/app/Http/Controllers/RoleCrudController.php
@@ -5,6 +5,7 @@ namespace Backpack\PermissionManager\app\Http\Controllers;
 use Backpack\CRUD\app\Http\Controllers\CrudController;
 use Backpack\PermissionManager\app\Http\Requests\RoleStoreCrudRequest as StoreRequest;
 use Backpack\PermissionManager\app\Http\Requests\RoleUpdateCrudRequest as UpdateRequest;
+use Spatie\Permission\PermissionRegistrar;
 
 // VALIDATION
 
@@ -104,7 +105,7 @@ class RoleCrudController extends CrudController
         $this->crud->setValidation(StoreRequest::class);
 
         //otherwise, changes won't have effect
-        \Cache::forget('spatie.permission.cache');
+        app()->make(PermissionRegistrar::class)->forgetCachedPermissions();
     }
 
     public function setupUpdateOperation()
@@ -113,7 +114,7 @@ class RoleCrudController extends CrudController
         $this->crud->setValidation(UpdateRequest::class);
 
         //otherwise, changes won't have effect
-        \Cache::forget('spatie.permission.cache');
+        app()->make(PermissionRegistrar::class)->forgetCachedPermissions();
     }
 
     private function addFields()


### PR DESCRIPTION
## WHY

The **laravel-permission** package uses the caching key that is specified in the [config](https://github.com/spatie/laravel-permission/blob/da5c8bc931692fa0a1a0fbda1a5995c9379e4159/config/permission.php#L176) and which can be changed.

But **PermissionManager** resets the cache directly using the hard-coded key.

```php
\Cache::forget('spatie.permission.cache');
```

### AFTER - What is happening after this PR?

Now, to reset the cache, the [recommendation](https://spatie.be/docs/laravel-permission/v6/advanced-usage/cache#content-manual-cache-reset) of the developers of the **laravel-permission** package was used.
